### PR TITLE
feat: iOS expert skills integration via suggest_in pattern

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
     "name": "Alessio Roberto"
   },
   "metadata": {
-    "description": "BMAD: Multi-agent development workflow plugin with named holacracy roles"
+    "description": "BMAD: Multi-agent development workflow plugin with holacracy roles, quality gates, and full customization"
   },
   "plugins": [
     {
       "name": "bmad",
       "version": "0.1.0",
       "source": "./plugin",
-      "description": "8 named AI agents (Mary, Winston, Amelia, Murat, Sally, John, Bob, Doris) for structured development workflows"
+      "description": "Multi-agent development workflow plugin with holacracy roles, quality gates, and full customization"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ allowed-tools: Read, Grep, Glob, Bash
 - **Soul is mandatory**: Every role must reference and follow `plugin/resources/soul.md`
 - **Dependencies are optional**: All dependencies are declared in `deps-manifest.yaml`. `bmad-init` detects missing deps and offers installation. Roles degrade gracefully when dependencies are missing
 - **Templates live in resources**: Document templates go in `plugin/resources/templates/docs/` or `plugin/resources/templates/software/`
-- **Template variants**: Domain-specific template variants use `-{domain}` suffix (e.g., `module-architecture-swift.md`). Base templates are always language-agnostic. `bmad-docs` auto-selects by domain detection
+- **Template variants**: Template variants use `-{technology}` suffix (e.g., `-swift`, `-node`). Technology is detected from marker files by `bmad-docs`, distinct from the 4-domain model used by other roles. Base templates are always language-agnostic
 - **Domain-agnostic core**: Skills must NOT name-drop specific MCP tools (Cupertino, SwiftUI Expert, etc.) — use "Domain-specific tools" generically. Domain-specific deps live only in `deps-manifest.yaml`
 - **Do not touch for neutralization**: `deps-manifest.yaml`, `bmad-init/SKILL.md`, and `bmad-triage/SKILL.md` contain domain-specific content by design (installer, multi-domain tables). These are correct patterns, not iOS bias
 - **docs/MIGRATION.md**: Contains intentional persona name references (Mary, Winston, etc.) for migration mapping — do not remove

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ plugin/
     └── bmad-shard/SKILL.md             # Context sharding utility
 docs/
 ├── CUSTOMIZATION.md                    # 8-layer customization guide
+├── GETTING-STARTED.md                  # Non-technical getting started guide
 └── MIGRATION.md                        # Migration from old BMAD-Setup
 ```
 
@@ -84,8 +85,12 @@ allowed-tools: Read, Grep, Glob, Bash
 - **Domain detection**: Roles detect project type by looking for marker files (Package.swift, package.json, etc.) and adjust behavior accordingly
 - **Quality gates**: P0 security blocks stop workflow before implementation. QA rejection loops back to the Implementer. Completeness checks verify outputs exist before advancing
 - **Zero project footprint**: All BMAD outputs go to `~/.claude/bmad/projects/<project>/`. Nothing is committed to the repo
-- **MCP tools are optional**: Roles check for Linear, Cupertino, claude-mem availability but degrade gracefully if absent
+- **MCP tools are optional**: Roles check for MCP tools (Linear, claude-mem, and domain-specific servers) but degrade gracefully if absent
 - **Soul is mandatory**: Every role must reference and follow `plugin/resources/soul.md`
 - **Dependencies are optional**: All dependencies are declared in `deps-manifest.yaml`. `bmad-init` detects missing deps and offers installation. Roles degrade gracefully when dependencies are missing
 - **Templates live in resources**: Document templates go in `plugin/resources/templates/docs/` or `plugin/resources/templates/software/`
+- **Template variants**: Domain-specific template variants use `-{domain}` suffix (e.g., `module-architecture-swift.md`). Base templates are always language-agnostic. `bmad-docs` auto-selects by domain detection
+- **Domain-agnostic core**: Skills must NOT name-drop specific MCP tools (Cupertino, SwiftUI Expert, etc.) — use "Domain-specific tools" generically. Domain-specific deps live only in `deps-manifest.yaml`
+- **Do not touch for neutralization**: `deps-manifest.yaml`, `bmad-init/SKILL.md`, and `bmad-triage/SKILL.md` contain domain-specific content by design (installer, multi-domain tables). These are correct patterns, not iOS bias
+- **docs/MIGRATION.md**: Contains intentional persona name references (Mary, Winston, etc.) for migration mapping — do not remove
 - **Holacracy alignment**: Roles have purposes and accountabilities, not personas. Communication references roles, never personal names. External communication uses team voice, not role voice

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ allowed-tools: Read, Grep, Glob, Bash
 - **Templates live in resources**: Document templates go in `plugin/resources/templates/docs/` or `plugin/resources/templates/software/`
 - **Template variants**: Template variants use `-{technology}` suffix (e.g., `-swift`, `-node`). Technology is detected from marker files by `bmad-docs`, distinct from the 4-domain model used by other roles. Base templates are always language-agnostic
 - **Domain-agnostic core**: Skills must NOT name-drop specific MCP tools (Cupertino, SwiftUI Expert, etc.) — use "Domain-specific tools" generically. Domain-specific deps live only in `deps-manifest.yaml`
+- **Skill suggestions via deps-manifest**: Domain-specific skill suggestions use the `suggest_in` field in `deps-manifest.yaml`, mapping role names to contextual suggestion text. Roles read this field generically — never hardcode skill names in SKILL.md files. To add suggestions for a new domain, add `suggest_in` entries to deps-manifest only
 - **Do not touch for neutralization**: `deps-manifest.yaml`, `bmad-init/SKILL.md`, and `bmad-triage/SKILL.md` contain domain-specific content by design (installer, multi-domain tables). These are correct patterns, not iOS bias
 - **docs/MIGRATION.md**: Contains intentional persona name references (Mary, Winston, etc.) for migration mapping — do not remove
 - **Holacracy alignment**: Roles have purposes and accountabilities, not personas. Communication references roles, never personal names. External communication uses team voice, not role voice

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,8 @@ allowed-tools: Read, Grep, Glob, Bash
 - **Template variants**: Template variants use `-{technology}` suffix (e.g., `-swift`, `-node`). Technology is detected from marker files by `bmad-docs`, distinct from the 4-domain model used by other roles. Base templates are always language-agnostic
 - **Domain-agnostic core**: Skills must NOT name-drop specific MCP tools (Cupertino, SwiftUI Expert, etc.) — use "Domain-specific tools" generically. Domain-specific deps live only in `deps-manifest.yaml`
 - **Skill suggestions via deps-manifest**: Domain-specific skill suggestions use the `suggest_in` field in `deps-manifest.yaml`, mapping role names to contextual suggestion text. Roles read this field generically — never hardcode skill names in SKILL.md files. To add suggestions for a new domain, add `suggest_in` entries to deps-manifest only
+- **Scripts mirror deps-manifest**: `install-deps.sh` and `update-deps.sh` have hardcoded parallel arrays — they do NOT parse `deps-manifest.yaml`. Any dep added to the manifest MUST also be added to both scripts
+- **Version bump**: After feature work, update `version` in `plugin/.claude-plugin/plugin.json` before pushing
 - **Do not touch for neutralization**: `deps-manifest.yaml`, `bmad-init/SKILL.md`, and `bmad-triage/SKILL.md` contain domain-specific content by design (installer, multi-domain tables). These are correct patterns, not iOS bias
 - **docs/MIGRATION.md**: Contains intentional persona name references (Mary, Winston, etc.) for migration mapping — do not remove
 - **Holacracy alignment**: Roles have purposes and accountabilities, not personas. Communication references roles, never personal names. External communication uses team voice, not role voice

--- a/README.md
+++ b/README.md
@@ -80,13 +80,20 @@ All dependencies are **optional** — roles work without them and adapt when too
 |---|---|---|---|
 | Linear | Cloud MCP | Core | Issue tracking and sprint management for all roles |
 | claude-mem | Plugin | Core | Memory that persists across sessions for all roles |
-| Cupertino | Brew MCP | iOS | Apple documentation and Human Interface Guidelines for iOS projects |
-| SwiftUI Expert | Plugin | iOS | SwiftUI best practices and patterns |
-| Swift LSP | Plugin | iOS | Code intelligence for Swift files |
 | Notion | Plugin | Extras | The Documentation Steward can publish docs to Notion |
 | bmad-mcp | npm | Extras | Additional workflow tools for Greenfield orchestrator |
 
-> **MCP** = Model Context Protocol — a way for Claude to connect to external services (like Linear or Apple docs). Think of it as a plugin for the plugin.
+**Domain-Specific (iOS):**
+
+| Dependency | Type | What it adds |
+|---|---|---|
+| Cupertino | Brew MCP | Apple documentation and Human Interface Guidelines |
+| SwiftUI Expert | Plugin | SwiftUI best practices and patterns |
+| Swift LSP | Plugin | Code intelligence for Swift files |
+
+Domain-specific dependencies are auto-detected by `bmad-init` based on project marker files (e.g., `Package.swift` for iOS). See `deps-manifest.yaml` for conditions.
+
+> **MCP** = Model Context Protocol — a way for Claude to connect to external services. Think of it as a plugin for the plugin.
 
 ```bash
 # First-time setup (interactive — walks you through what to install)
@@ -157,8 +164,8 @@ Roles connect to external services through MCP (Model Context Protocol) when ava
 | MCP Server | Used By | What it provides |
 |---|---|---|
 | Linear | All roles | Issue tracking, sprint management |
-| Cupertino | Architecture Owner, Implementer, Experience Designer | Apple documentation, Human Interface Guidelines, Swift APIs |
 | claude-mem | All roles | Memory that persists across Claude Code sessions |
+| Domain-specific tools | Roles with domain detection | Platform documentation and framework APIs (e.g., Cupertino for iOS) |
 
 ## Customization
 
@@ -174,11 +181,11 @@ agents:
     context_files:
       - docs/ARCHITECTURE.md
     extra_instructions: |
-      This project uses MVVM+C with Combine.
+      This project uses a layered architecture with dependency injection.
 
   bmad-impl:
     extra_instructions: |
-      Use Swift 6 strict concurrency.
+      Follow project coding standards and existing conventions.
 ```
 
 ### Adding Roles

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -48,11 +48,11 @@ agents:
     context_files:
       - docs/ARCHITECTURE.md
     extra_instructions: |
-      This project uses MVVM+C with Combine.
+      This project uses a layered architecture with dependency injection.
 
   bmad-impl:
     extra_instructions: |
-      Use Swift 6 strict concurrency.
+      Follow project coding standards and existing conventions.
 ```
 
 See `plugin/resources/templates/config-example.yaml` for a full example with all available options.
@@ -163,15 +163,15 @@ To add a new role to the greenfield orchestrator:
 
 > This section is for developers who want to connect BMAD roles to external services via MCP (Model Context Protocol).
 
-Roles reference MCP tools (Linear, Cupertino, claude-mem) but degrade gracefully if unavailable. To configure:
+Roles reference MCP tools (Linear, claude-mem, and domain-specific servers) but degrade gracefully if unavailable. To configure:
 
 - **Linear**: Set up Linear MCP server in Claude Code settings
-- **Cupertino**: Set up Cupertino MCP server for Apple docs
 - **claude-mem**: Install claude-mem plugin for cross-session memory
+- **Domain-specific tools**: Configured via `deps-manifest.yaml` groups (e.g., Cupertino for iOS, installed automatically by `bmad-init` when domain markers are detected)
 
 Per-project Linear mapping in `config.yaml`:
 ```yaml
 linear:
-  team: "iOS"
+  team: "My Team"
   project: "My Project"
 ```

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -51,7 +51,7 @@ Config keys have also changed (e.g., `bmad-winston` → `bmad-arch`, `bmad-ameli
 
 - Output location: `~/.claude/bmad/projects/<project>/output/`
 - Soul principles (now with holacracy section)
-- MCP integrations (Linear, Cupertino, claude-mem)
+- MCP integrations (Linear, claude-mem, and domain-specific servers)
 - Zero project footprint
 - Session state format
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bmad",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Multi-agent development workflow plugin with holacracy roles, quality gates, and full customization",
   "author": {
     "name": "Alessio Roberto",

--- a/plugin/commands/bmad.md
+++ b/plugin/commands/bmad.md
@@ -87,19 +87,16 @@ Check dependency versions: Read `~/.claude/plugins/installed_plugins.json` and c
 
 ```
 Dependencies:
-  Plugins:
-    code-review     <version/hash>  (auto-update)
-    feature-dev     <version/hash>  (auto-update)
-    github          <version/hash>  (auto-update)
-    swift-lsp       <version>
-    swiftui-expert  <version>
+  Core:
     claude-mem      <version>
+    Linear          cloud (managed by Claude)
+
+  Extras:
+    bmad-mcp        <version from npm list -g bmad-mcp>
     Notion          <version>
 
-  MCP Servers:
-    bmad-mcp        <version from npm list -g bmad-mcp>
-    cupertino       <version> (brew tap mihaelamj/tap)
-    Linear          cloud (managed by Claude)
+  Domain-Specific (if detected):
+    <list installed domain deps from deps-manifest.yaml>
 
   Local:
     bmad  <version from plugin.json>

--- a/plugin/resources/deps-manifest.yaml
+++ b/plugin/resources/deps-manifest.yaml
@@ -1,6 +1,6 @@
 # BMAD — Dependency Manifest
 # Single source of truth for all optional dependencies.
-# Read by: install-deps.sh, update-deps.sh, bmad-init.
+# Read by: install-deps.sh, update-deps.sh, bmad-init, bmad-arch, bmad-impl, bmad-qa.
 #
 # Override per-project in ~/.claude/bmad/projects/<project>/config.yaml
 # under the "dependencies:" key.

--- a/plugin/resources/deps-manifest.yaml
+++ b/plugin/resources/deps-manifest.yaml
@@ -53,6 +53,10 @@ groups:
         install_command: "claude plugin marketplace add swiftui-expert-skill && claude plugin install swiftui-expert@swiftui-expert-skill"
         update_command: "claude plugin marketplace update swiftui-expert-skill && claude plugin update swiftui-expert@swiftui-expert-skill"
         used_by: "arch, impl, ux"
+        suggest_in:
+          arch: "SwiftUI state management and view architecture decisions"
+          impl: "implementing SwiftUI views and components"
+          ux: "UI patterns and platform design guidelines"
 
       - id: swift-lsp
         type: plugin
@@ -73,6 +77,9 @@ groups:
         install_command: "claude plugin marketplace add AvdLee/Swift-Concurrency-Agent-Skill && claude plugin install swift-concurrency@AvdLee/Swift-Concurrency-Agent-Skill"
         update_command: "claude plugin marketplace update AvdLee/Swift-Concurrency-Agent-Skill && claude plugin update swift-concurrency@AvdLee/Swift-Concurrency-Agent-Skill"
         used_by: "arch, impl"
+        suggest_in:
+          arch: "concurrency model, actor isolation, and async/await architecture"
+          impl: "implementing async/await, actors, or Task-based code"
 
       - id: swift-testing-expert
         type: plugin
@@ -83,6 +90,9 @@ groups:
         install_command: "claude plugin marketplace add AvdLee/Swift-Testing-Agent-Skill && claude plugin install swift-testing-expert@AvdLee/Swift-Testing-Agent-Skill"
         update_command: "claude plugin marketplace update AvdLee/Swift-Testing-Agent-Skill && claude plugin update swift-testing-expert@AvdLee/Swift-Testing-Agent-Skill"
         used_by: "qa, impl"
+        suggest_in:
+          qa: "test quality review and Swift Testing patterns"
+          impl: "writing tests with Swift Testing framework"
 
   extras:
     label: "Additional tools"

--- a/plugin/resources/deps-manifest.yaml
+++ b/plugin/resources/deps-manifest.yaml
@@ -64,6 +64,26 @@ groups:
         update_command: "claude plugin marketplace update claude-plugins-official && claude plugin update swift-lsp@claude-plugins-official"
         used_by: "impl"
 
+      - id: swift-concurrency
+        type: plugin
+        name: Swift Concurrency
+        marketplace: AvdLee/Swift-Concurrency-Agent-Skill
+        description: "async/await, actors, Sendable, Swift 6 concurrency"
+        check_command: "grep -q swift-concurrency ~/.claude/plugins/installed_plugins.json 2>/dev/null"
+        install_command: "claude plugin marketplace add AvdLee/Swift-Concurrency-Agent-Skill && claude plugin install swift-concurrency@AvdLee/Swift-Concurrency-Agent-Skill"
+        update_command: "claude plugin marketplace update AvdLee/Swift-Concurrency-Agent-Skill && claude plugin update swift-concurrency@AvdLee/Swift-Concurrency-Agent-Skill"
+        used_by: "arch, impl"
+
+      - id: swift-testing-expert
+        type: plugin
+        name: Swift Testing Expert
+        marketplace: AvdLee/Swift-Testing-Agent-Skill
+        description: "Swift Testing framework, #expect/#require, XCTest migration"
+        check_command: "grep -q swift-testing-expert ~/.claude/plugins/installed_plugins.json 2>/dev/null"
+        install_command: "claude plugin marketplace add AvdLee/Swift-Testing-Agent-Skill && claude plugin install swift-testing-expert@AvdLee/Swift-Testing-Agent-Skill"
+        update_command: "claude plugin marketplace update AvdLee/Swift-Testing-Agent-Skill && claude plugin update swift-testing-expert@AvdLee/Swift-Testing-Agent-Skill"
+        used_by: "qa, impl"
+
   extras:
     label: "Additional tools"
     deps:

--- a/plugin/resources/scripts/install-deps.sh
+++ b/plugin/resources/scripts/install-deps.sh
@@ -36,6 +36,8 @@ DEPS=(
   "cupertino|ios|mcp-brew|Cupertino|Apple documentation MCP server|command -v cupertino|brew tap mihaelamj/tap && brew install cupertino|arch impl ux|brew|"
   "swiftui-expert|ios|plugin|SwiftUI Expert|SwiftUI design patterns and best practices|grep -q swiftui-expert $PLUGINS_JSON 2>/dev/null|claude plugin marketplace add swiftui-expert-skill && claude plugin install swiftui-expert@swiftui-expert-skill|arch impl ux||"
   "swift-lsp|ios|plugin|Swift LSP|Swift language server integration|grep -q swift-lsp $PLUGINS_JSON 2>/dev/null|claude plugin marketplace add claude-plugins-official && claude plugin install swift-lsp@claude-plugins-official|impl||"
+  "swift-concurrency|ios|plugin|Swift Concurrency|async/await actors Sendable Swift 6|grep -q swift-concurrency $PLUGINS_JSON 2>/dev/null|claude plugin marketplace add AvdLee/Swift-Concurrency-Agent-Skill && claude plugin install swift-concurrency@AvdLee/Swift-Concurrency-Agent-Skill|arch impl||"
+  "swift-testing-expert|ios|plugin|Swift Testing Expert|Swift Testing framework #expect #require|grep -q swift-testing-expert $PLUGINS_JSON 2>/dev/null|claude plugin marketplace add AvdLee/Swift-Testing-Agent-Skill && claude plugin install swift-testing-expert@AvdLee/Swift-Testing-Agent-Skill|qa impl||"
   "notion|extras|plugin|Notion|Notion workspace integration|grep -q Notion $PLUGINS_JSON 2>/dev/null|claude plugin marketplace add claude-plugins-official && claude plugin install Notion@claude-plugins-official|docs||"
   "bmad-mcp|extras|npm|bmad-mcp|BMAD MCP server for workflow orchestration|npm list -g bmad-mcp 2>/dev/null \| grep -q bmad-mcp|npm install -g bmad-mcp|greenfield||"
 )

--- a/plugin/resources/scripts/update-deps.sh
+++ b/plugin/resources/scripts/update-deps.sh
@@ -20,6 +20,8 @@ echo "→ Updating marketplace indexes..."
 claude plugin marketplace update claude-plugins-official 2>/dev/null || echo "  ⚠ claude-plugins-official: update failed (may not be registered)"
 claude plugin marketplace update swiftui-expert-skill 2>/dev/null || echo "  ⚠ swiftui-expert-skill: update failed"
 claude plugin marketplace update thedotmack 2>/dev/null || echo "  ⚠ thedotmack: update failed"
+claude plugin marketplace update AvdLee/Swift-Concurrency-Agent-Skill 2>/dev/null || echo "  ⚠ Swift-Concurrency: update failed"
+claude plugin marketplace update AvdLee/Swift-Testing-Agent-Skill 2>/dev/null || echo "  ⚠ Swift-Testing: update failed"
 echo ""
 
 # 2. Plugins — update installed ones
@@ -28,6 +30,8 @@ claude plugin update swift-lsp@claude-plugins-official 2>/dev/null || echo "  �
 claude plugin update swiftui-expert@swiftui-expert-skill 2>/dev/null || echo "  ⚠ swiftui-expert: update failed"
 claude plugin update claude-mem@thedotmack 2>/dev/null || echo "  ⚠ claude-mem: update failed"
 claude plugin update Notion@claude-plugins-official 2>/dev/null || echo "  ⚠ Notion: update failed"
+claude plugin update swift-concurrency@AvdLee/Swift-Concurrency-Agent-Skill 2>/dev/null || echo "  ⚠ swift-concurrency: update failed"
+claude plugin update swift-testing-expert@AvdLee/Swift-Testing-Agent-Skill 2>/dev/null || echo "  ⚠ swift-testing-expert: update failed"
 # code-review, feature-dev, github auto-update (Anthropic official)
 echo ""
 

--- a/plugin/resources/templates/config-example.yaml
+++ b/plugin/resources/templates/config-example.yaml
@@ -9,6 +9,10 @@
 # Domain override (skip auto-detection)
 # domain: software
 
+# Template variant overrides (force a specific template variant)
+# templates:
+#   module-architecture: module-architecture-swift  # Force Swift variant
+
 # Optional phases enabled by default for greenfield workflow
 greenfield_defaults:
   ux: true
@@ -24,16 +28,15 @@ agents:
       - docs/ADR/
     # Extra instructions appended to the role's prompt
     extra_instructions: |
-      This project uses MVVM+C architecture with Combine.
+      This project uses a layered architecture with dependency injection.
       All new modules must follow the existing pattern.
 
   bmad-impl:
     context_files:
-      - Sources/
+      - src/
     extra_instructions: |
-      Use Swift 6 strict concurrency.
+      Follow project coding standards and existing conventions.
       All public APIs must have documentation comments.
-      Follow existing code style and conventions.
 
   bmad-qa:
     extra_instructions: |
@@ -42,12 +45,12 @@ agents:
 
   bmad-ux:
     extra_instructions: |
-      Follow Apple HIG for iOS.
-      Support Dynamic Type and VoiceOver.
+      Follow platform design guidelines.
+      Support accessibility features.
 
 # Linear project mapping (for MCP integration)
 # linear:
-#   team: "iOS"
+#   team: "My Team"
 #   project: "My Project"
 
 # claude-mem project name (for memory search scoping)
@@ -57,7 +60,6 @@ agents:
 # Override which dependencies are installed for this project.
 # See deps-manifest.yaml for the full list of available dependencies.
 # dependencies:
-#   cupertino: skip          # Don't install this dependency
 #   notion: include          # Include an extra that's off by default
 #   claude-mem:              # Replace a default with an alternative
 #     skip: true

--- a/plugin/resources/templates/docs/module-architecture-swift.md
+++ b/plugin/resources/templates/docs/module-architecture-swift.md
@@ -103,7 +103,7 @@ flowchart TD
 
 ### 1. {ComponentName}
 
-**Location**: `{path}/{ComponentName}.{ext}`
+**Location**: `{path}/{ComponentName}.swift`
 
 {Brief description of what this component does}
 
@@ -119,7 +119,7 @@ flowchart TD
 
 ### 2. {ComponentName}
 
-**Location**: `{path}/{ComponentName}.{ext}`
+**Location**: `{path}/{ComponentName}.swift`
 
 {Brief description}
 
@@ -132,10 +132,10 @@ flowchart TD
 
 Configuration struct for controlling behavior:
 
-```pseudocode
-type {ConfigName} {
-    {property}: {Type}     // {Comment}
-    {property}: {Type}     // {Comment}
+```swift
+struct {ConfigName} {
+    let {property}: {Type}     // {Comment}
+    let {property}: {Type}     // {Comment}
 }
 ```
 
@@ -187,10 +187,10 @@ Triggered by: {trigger conditions}
 
 Errors are tracked via `{ErrorType}` and monitored through {monitoring system}:
 
-```pseudocode
-type {ErrorType} implements {Protocol} {
-    type: String        // {comment}
-    message: String?    // {comment}
+```swift
+struct {ErrorType}: {Protocol} {
+    var type: String        // {comment}
+    var message: String?    // {comment}
 }
 ```
 

--- a/plugin/resources/templates/docs/reusable-ui-swift.md
+++ b/plugin/resources/templates/docs/reusable-ui-swift.md
@@ -12,7 +12,7 @@
 {Brief description and its scope}
 
 ## Location
-`{path}/{ComponentName}.{ext}`
+`{path}/{ComponentName}.swift`
 
 ## Supported Parameters
 - [ ] {Parameter 1}
@@ -21,15 +21,15 @@
 
 ## Interface
 
-```pseudocode
-component {ComponentName} {
+```swift
+struct {ComponentName}: View {
     // Required
-    title: String
-    value: String
+    let title: String
+    let value: String
 
     // Optional
-    unit: String?
-    trend: Trend?
+    var unit: String?
+    var trend: Trend?
 }
 ```
 
@@ -44,7 +44,7 @@ component {ComponentName} {
 
 ## Usage Example
 
-```pseudocode
+```swift
 {ComponentName}(
     title: "{Parameter}",
     value: "{Value}",

--- a/plugin/resources/templates/software/security-audit.md
+++ b/plugin/resources/templates/software/security-audit.md
@@ -25,12 +25,12 @@
 | A09 | Logging Failures | Pass/Fail/N/A | {Notes} |
 | A10 | SSRF | Pass/Fail/N/A | {Notes} |
 
-## iOS-Specific Security
+## Platform-Specific Security
 
-- **Keychain usage**: {Assessment}
-- **App Transport Security**: {Assessment}
-- **Data Protection**: {Assessment}
-- **Biometric auth**: {Assessment}
+- **{Platform security concern 1}**: {Assessment}
+- **{Platform security concern 2}**: {Assessment}
+- **{Platform security concern 3}**: {Assessment}
+- **{Platform security concern 4}**: {Assessment}
 
 ## Findings
 

--- a/plugin/skills/bmad-arch/SKILL.md
+++ b/plugin/skills/bmad-arch/SKILL.md
@@ -55,6 +55,14 @@ Also check for project config: `~/.claude/bmad/projects/{project}/config.yaml`
 - Performance & Scalability considerations
 - Security considerations
 
+**Domain Skill Suggestions**:
+
+Check `${CLAUDE_PLUGIN_ROOT}/resources/deps-manifest.yaml` for domain-specific dependency groups that match the detected project type (e.g., `ios` group when `Package.swift` or `*.xcodeproj` exists). For each dependency in a matching group that has a `suggest_in` entry for this role (`arch`), suggest:
+
+> "Consider invoking `/<dep-id>` for <suggest_in text>"
+
+These are suggestions, not blocks — proceed with or without them. If a suggested skill is not installed, note: "Not installed. Run: `<install_command>` from deps-manifest."
+
 ### Business Strategy
 **Focus**: Process design, workflow, organizational structure
 **Output filename**: `operational-architecture.md`

--- a/plugin/skills/bmad-arch/SKILL.md
+++ b/plugin/skills/bmad-arch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bmad-arch
-description: Architecture Owner — Designs solutions, evaluates trade-offs, creates ADRs. Use after requirements are defined. Has access to Apple documentation via Cupertino MCP.
+description: Architecture Owner — Designs solutions, evaluates trade-offs, creates ADRs. Use after requirements are defined.
 context: fork
 agent: Plan
 allowed-tools: Read, Grep, Glob, Bash
@@ -107,8 +107,7 @@ Also check for project config: `~/.claude/bmad/projects/{project}/config.yaml`
 6. **Generate architecture document**: Write to `~/.claude/bmad/projects/$PROJECT_NAME/output/arch/{filename}`
 
 7. **MCP Integration** (if available):
-   - **Cupertino**: Look up Apple frameworks, APIs, and best practices when designing iOS/Swift architecture
-   - **SwiftUI Expert**: Reference SwiftUI patterns for UI architecture decisions
+   - **Domain-specific tools**: If domain-specific MCP tools are available (configured via deps-manifest.yaml), use them to look up framework documentation and platform best practices.
    - **Linear**: Reference project context and link architecture decisions to issues
    - **claude-mem**: Search for past architectural decisions in similar projects. Save key ADRs at completion.
 

--- a/plugin/skills/bmad-docs/SKILL.md
+++ b/plugin/skills/bmad-docs/SKILL.md
@@ -38,6 +38,16 @@ Available templates:
 
 Ask the user: "Which template do you want to use?"
 
+### Step 1b: Select Template Variant
+
+After the user selects a template, check for domain-specific variants:
+
+1. Detect domain using standard domain detection (marker files in current directory)
+2. Check if a variant exists: `{template-name}-{domain}.md` (e.g., `module-architecture-swift.md`)
+3. Check `config.yaml` for a `templates:` override (e.g., `module-architecture: module-architecture-swift`)
+4. Priority: config override > domain variant > base template
+5. If a variant is selected, inform the user: "Using {variant} template for {domain} project."
+
 ### Step 2: Get Target Module/Feature
 
 Ask the user: "Which module or feature do you want to generate documentation for?"
@@ -60,7 +70,7 @@ For the target module:
 ### Step 5: Analyze Code and Git
 
 For the target module:
-- Extract Swift declarations (classes, structs, protocols, methods)
+- Extract code declarations (classes, types, interfaces, functions)
 - Run git analysis:
   - `git shortlog -s -n -- {module_path}` for contributors
   - `git log --oneline -- {module_path}` for commit history
@@ -110,7 +120,7 @@ Report: "Document saved to: {path}"
 |---------|--------|
 | `{Module Name}` | User input |
 | `{Capability N}` | Code analysis |
-| `{ComponentName}` | Swift declarations |
+| `{ComponentName}` | Code declarations |
 | `{Trigger}`, `{What Happens}` | Code flow analysis |
 | `{AUTO:date}` | Current date |
 | `{AUTO:contributors}` | git shortlog |

--- a/plugin/skills/bmad-docs/SKILL.md
+++ b/plugin/skills/bmad-docs/SKILL.md
@@ -40,13 +40,20 @@ Ask the user: "Which template do you want to use?"
 
 ### Step 1b: Select Template Variant
 
-After the user selects a template, check for domain-specific variants:
+After the user selects a template, check for technology-specific variants:
 
-1. Detect domain using standard domain detection (marker files in current directory)
-2. Check if a variant exists: `{template-name}-{domain}.md` (e.g., `module-architecture-swift.md`)
+1. Detect technology from marker files in the current directory:
+   - `Package.swift`, `*.xcodeproj` → `swift`
+   - `package.json` → `node`
+   - `pom.xml` → `java`
+   - `requirements.txt`, `pyproject.toml` → `python`
+   - `go.mod` → `go`
+   - `Cargo.toml` → `rust`
+2. Check if a variant exists: `{template-name}-{technology}.md` (e.g., `module-architecture-swift.md`)
 3. Check `config.yaml` for a `templates:` override (e.g., `module-architecture: module-architecture-swift`)
-4. Priority: config override > domain variant > base template
-5. If a variant is selected, inform the user: "Using {variant} template for {domain} project."
+4. Priority: config override > technology variant > base template
+5. If a variant is selected, inform the user: "Using {variant} template for {technology} project."
+6. If no technology match or no variant file exists, use the base template.
 
 ### Step 2: Get Target Module/Feature
 

--- a/plugin/skills/bmad-impl/SKILL.md
+++ b/plugin/skills/bmad-impl/SKILL.md
@@ -55,6 +55,14 @@ If directory `~/.claude/bmad/projects/{project}/shards/stories/` exists:
 - Add tests (unit, integration)
 - Self-review before handoff
 
+**Domain Skill Suggestions**:
+
+Check `${CLAUDE_PLUGIN_ROOT}/resources/deps-manifest.yaml` for domain-specific dependency groups that match the detected project type (e.g., `ios` group when `Package.swift` or `*.xcodeproj` exists). For each dependency in a matching group that has a `suggest_in` entry for this role (`impl`), suggest:
+
+> "Consider invoking `/<dep-id>` for <suggest_in text>"
+
+These are suggestions, not blocks — proceed with or without them. If a suggested skill is not installed, note: "Not installed. Run: `<install_command>` from deps-manifest."
+
 ### Business Strategy
 **Activities**:
 - Create operational documents (procedures, guidelines, templates)

--- a/plugin/skills/bmad-impl/SKILL.md
+++ b/plugin/skills/bmad-impl/SKILL.md
@@ -94,8 +94,7 @@ If directory `~/.claude/bmad/projects/{project}/shards/stories/` exists:
 7. **Save implementation notes** to: `~/.claude/bmad/projects/$PROJECT_NAME/output/impl/implementation-notes-{date}.md`
 
 8. **MCP Integration** (if available):
-   - **Cupertino**: Look up Apple APIs and framework documentation during implementation
-   - **SwiftUI Expert**: Reference SwiftUI patterns and best practices
+   - **Domain-specific tools**: If domain-specific MCP tools are available (configured via deps-manifest.yaml), use them to look up framework documentation and platform best practices.
    - **Linear**: Update issue status, comment on implementation progress
    - **claude-mem**: Search for past implementation patterns. Save key decisions at completion.
 

--- a/plugin/skills/bmad-init/SKILL.md
+++ b/plugin/skills/bmad-init/SKILL.md
@@ -174,7 +174,7 @@ Domain: <detected-domain>
 Output: ~/.claude/bmad/projects/<project-name>/output/
 
 Dependencies:
-  [ok] claude-mem  [ok] Linear  [--] Cupertino  [ok] SwiftUI Expert
+  <summary of installed/missing from deps-manifest.yaml check>
   Install missing: bash <plugin-root>/resources/scripts/install-deps.sh
   Update all:      bash <plugin-root>/resources/scripts/update-deps.sh
 

--- a/plugin/skills/bmad-qa/SKILL.md
+++ b/plugin/skills/bmad-qa/SKILL.md
@@ -47,6 +47,14 @@ Read from `~/.claude/bmad/projects/{project}/output/`:
 - Verify test coverage for implemented features
 - Run existing tests and report results
 
+**Domain Skill Suggestions**:
+
+Check `${CLAUDE_PLUGIN_ROOT}/resources/deps-manifest.yaml` for domain-specific dependency groups that match the detected project type (e.g., `ios` group when `Package.swift` or `*.xcodeproj` exists). For each dependency in a matching group that has a `suggest_in` entry for this role (`qa`), suggest:
+
+> "Consider invoking `/<dep-id>` for <suggest_in text>"
+
+These are suggestions, not blocks — proceed with or without them. If a suggested skill is not installed, note: "Not installed. Run: `<install_command>` from deps-manifest."
+
 ### Business Strategy
 **Focus**: Process validation, feasibility checks
 **Output filename**: `validation-report.md`

--- a/plugin/skills/bmad-ux/SKILL.md
+++ b/plugin/skills/bmad-ux/SKILL.md
@@ -17,7 +17,7 @@ Key reminders: Impact over activity. User needs over developer preferences. Iter
 
 ## Your Role
 
-You are the advocate for the end user. You think in flows, not screens. You challenge feature requests that don't serve the user, and you simplify interactions that are unnecessarily complex. You respect Apple's Human Interface Guidelines but you're not dogmatic — you break conventions when there's a clear user benefit. You collaborate closely with the Architecture Owner on technical feasibility and with the Scope Clarifier on user requirements.
+You are the advocate for the end user. You think in flows, not screens. You challenge feature requests that don't serve the user, and you simplify interactions that are unnecessarily complex. You respect platform design guidelines but you're not dogmatic — you break conventions when there's a clear user benefit. You collaborate closely with the Architecture Owner on technical feasibility and with the Scope Clarifier on user requirements.
 
 ## Domain Detection
 
@@ -75,8 +75,7 @@ Read from `~/.claude/bmad/projects/{project}/output/`:
 7. **Generate UX design document**: Save to `~/.claude/bmad/projects/$PROJECT_NAME/output/ux/{filename}`
 
 8. **MCP Integration** (if available):
-   - **Cupertino**: Look up Human Interface Guidelines, SwiftUI components
-   - **SwiftUI Expert**: Reference SwiftUI view patterns and navigation
+   - **Domain-specific tools**: If domain-specific MCP tools are available (configured via deps-manifest.yaml), use them to look up platform design guidelines and UI component patterns.
    - **Linear**: Reference and link design decisions to issues
    - **claude-mem**: Search for past UX decisions. Save key design choices at completion.
 
@@ -88,5 +87,5 @@ Read from `~/.claude/bmad/projects/{project}/output/`:
 ## BMAD Principles
 - User needs first: design for the user, not for the developer
 - Simplicity: the best interface is the one the user doesn't notice
-- Platform conventions: follow HIG unless there's a clear reason not to
+- Platform conventions: follow platform guidelines unless there's a clear reason not to
 - Accessibility is not optional: design for everyone from the start

--- a/plugin/skills/bmad-ux/SKILL.md
+++ b/plugin/skills/bmad-ux/SKILL.md
@@ -43,7 +43,7 @@ Read from `~/.claude/bmad/projects/{project}/output/`:
 - Screen Wireframes (ASCII art)
 - Interaction Patterns (tap, swipe, navigation)
 - Accessibility Considerations
-- Platform Conventions (HIG compliance)
+- Platform Conventions (design guidelines compliance)
 - Error States and Edge Cases UX
 
 ### Business Strategy


### PR DESCRIPTION
## Summary

- Add `swift-concurrency` and `swift-testing-expert` (AvdLee) to iOS dependency group
- Introduce `suggest_in` field in `deps-manifest.yaml` for contextual skill suggestions
- Roles (arch, impl, qa) read suggest_in generically — no skill names hardcoded in SKILL.md
- Extensible pattern: adding skills for any new domain requires only deps-manifest changes

**Depends on**: #1 (domain-agnostic core)

## Changes (7 files modified)

**deps-manifest.yaml**:
- 2 new iOS deps: `swift-concurrency`, `swift-testing-expert`
- `suggest_in` field on 3 plugin-type deps mapping roles to contextual suggestion text
- iOS group total: 5 dependencies (was 3)

**Scripts** (kept in sync per ADR-002):
- `install-deps.sh`: 2 new DEPS array entries
- `update-deps.sh`: 4 new lines (marketplace + plugin updates)

**Skills** (domain-agnostic pattern):
- `bmad-arch`, `bmad-impl`, `bmad-qa`: Generic "Domain Skill Suggestions" section
- Section reads deps-manifest for matching domain groups, never names specific skills

**CLAUDE.md**: 3 new conventions (suggest_in, script sync, version bump)

**plugin.json**: Version bump 0.2.0 → 0.3.0

## Design decisions (ADRs)
- ADR-001: suggest_in in deps-manifest (not hardcoded in skills) — preserves domain-agnostic core
- ADR-002: Scripts must be updated in sync — install-deps.sh/update-deps.sh have hardcoded parallel arrays
- ADR-003: Domain Skill Suggestions placed inside Software Development section (not MCP Integration)

## Test plan
- [x] `grep -ri "AvdLee\|swift-concurrency\|swift-testing-expert" plugin/skills/` → 0 matches
- [x] `grep "suggest_in" deps-manifest.yaml` → 3 matches (correct)
- [x] iOS group has 5 deps (cupertino, swiftui-expert, swift-lsp, swift-concurrency, swift-testing-expert)
- [x] bmad-init reads deps-manifest dynamically (no changes needed)
- [x] 17/17 acceptance criteria passed (QA report in BMAD output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)