### PR TITLE
fix: align source repo with marketplace frontmatter format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "bmad",
       "version": "0.1.0",
       "source": "./plugin",
-      "description": "8 named AI agents (Mary, Winston, Amelia, Murat, Sally, John, Bob, Doris) for structured development workflows"
+      "description": "8 holacracy roles for structured development workflows with quality gates and full customization"
     }
   ]
 }

--- a/plugin/skills/bmad-arch/SKILL.md
+++ b/plugin/skills/bmad-arch/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: bmad-arch
 description: Architecture Owner — Designs solutions, evaluates trade-offs, creates ADRs. Use after requirements are defined. Has access to Apple documentation via Cupertino MCP.
-context: fork
-agent: Plan
 allowed-tools: Read, Grep, Glob, Bash
+metadata:
+  context: fork
+  agent: Plan
 ---
 
 # Architecture Owner

--- a/plugin/skills/bmad-code-review/SKILL.md
+++ b/plugin/skills/bmad-code-review/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: bmad-code-review
 description: "Code Review — Multi-agent PR review with CLAUDE.md compliance. Use on any open pull request."
-context: same
-agent: general-purpose
 allowed-tools: Read, Grep, Glob, Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(git rev-parse:*), Bash(git log:*), Bash(git blame:*)
+metadata:
+  context: same
+  agent: general-purpose
 ---
 
 # Code Review

--- a/plugin/skills/bmad-docs/SKILL.md
+++ b/plugin/skills/bmad-docs/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: bmad-docs
 description: Documentation Steward — Generates project documentation from templates using multi-agent analysis. Interactive 8-step workflow for architecture docs, ADRs, and reusable UI docs.
-context: same
-agent: general-purpose
 allowed-tools: Read, Write, Grep, Glob, Bash
+metadata:
+  context: same
+  agent: general-purpose
 ---
 
 # Documentation Steward

--- a/plugin/skills/bmad-facilitate/SKILL.md
+++ b/plugin/skills/bmad-facilitate/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: bmad-facilitate
 description: Facilitator — Plans sprints, coordinates team, removes blockers. Use for sprint planning, retrospectives, or workflow coordination.
-context: fork
-agent: general-purpose
 allowed-tools: Read, Grep, Glob, Bash
+metadata:
+  context: fork
+  agent: general-purpose
 ---
 
 # Facilitator

--- a/plugin/skills/bmad-greenfield/SKILL.md
+++ b/plugin/skills/bmad-greenfield/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: bmad-greenfield
 description: Orchestrates full greenfield workflow (init → Scope Clarifier → Prioritizer → Experience Designer → Architecture Owner → Security → Facilitator → Implementer → Quality Guardian). Interactive with human checkpoints at each phase. Optional phases (Experience Designer, Security, Facilitator). Resumable from any checkpoint.
-context: same
-agent: general-purpose
 allowed-tools: Read, Write, Grep, Glob, Bash
+metadata:
+  context: same
+  agent: general-purpose
 ---
 
 # BMAD Greenfield Workflow Orchestrator

--- a/plugin/skills/bmad-impl/SKILL.md
+++ b/plugin/skills/bmad-impl/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: bmad-impl
 description: Implementer — Implements solutions, writes code, performs code review. Use after architecture is designed. Supports context sharding for focused implementation.
-context: fork
-agent: general-purpose
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash
+metadata:
+  context: fork
+  agent: general-purpose
 ---
 
 # Implementer

--- a/plugin/skills/bmad-init/SKILL.md
+++ b/plugin/skills/bmad-init/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: bmad-init
 description: Initialize BMAD framework for the current project. Creates output directories in home folder (zero project footprint). Checks and installs optional dependencies. Run once per project.
-context: same
+metadata:
+  context: same
 ---
 
 # BMAD Init

--- a/plugin/skills/bmad-prioritize/SKILL.md
+++ b/plugin/skills/bmad-prioritize/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: bmad-prioritize
 description: Prioritizer — Prioritizes features, creates PRDs, manages roadmap. Use after initial requirements to refine and prioritize.
-context: fork
-agent: general-purpose
 allowed-tools: Read, Grep, Glob, Bash
+metadata:
+  context: fork
+  agent: general-purpose
 ---
 
 # Prioritizer

--- a/plugin/skills/bmad-qa/SKILL.md
+++ b/plugin/skills/bmad-qa/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: bmad-qa
 description: Quality Guardian — Plans testing strategy, validates quality, verifies implementations. Use after implementation or to plan testing upfront.
-context: fork
-agent: qa
 allowed-tools: Read, Grep, Glob, Bash
+metadata:
+  context: fork
+  agent: qa
 ---
 
 # Quality Guardian

--- a/plugin/skills/bmad-scope/SKILL.md
+++ b/plugin/skills/bmad-scope/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: bmad-scope
 description: Scope Clarifier — Gathers requirements, clarifies scope, breaks down user stories. Use to start a new feature or clarify ambiguous requirements.
-context: fork
-agent: Explore
 allowed-tools: Read, Grep, Glob, Bash
+metadata:
+  context: fork
+  agent: Explore
 ---
 
 # Scope Clarifier

--- a/plugin/skills/bmad-shard/SKILL.md
+++ b/plugin/skills/bmad-shard/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: bmad-shard
 description: Splits large documents (PRD, architecture) into atomic shards for context management. Reduces token usage by 90%. Use when PRD or architecture exceeds 3000 tokens.
-context: same
-agent: general-purpose
 allowed-tools: Read, Write, Grep, Glob, Bash
+metadata:
+  context: same
+  agent: general-purpose
 ---
 
 # BMAD Document Sharding

--- a/plugin/skills/bmad-sprint/SKILL.md
+++ b/plugin/skills/bmad-sprint/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: bmad-sprint
 description: Interactive sprint planning ceremony. 6-step process from backlog review to sprint commitment. Tracks story points in real time. Resumable.
-context: same
-agent: general-purpose
 allowed-tools: Read, Write, Grep, Glob, Bash
+metadata:
+  context: same
+  agent: general-purpose
 ---
 
 # BMAD Sprint Ceremony Orchestrator

--- a/plugin/skills/bmad-triage/SKILL.md
+++ b/plugin/skills/bmad-triage/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: bmad-triage
 description: "Triage — PR review comment handler. Analyzes, triages, and resolves review feedback."
-context: same
-agent: general-purpose
 allowed-tools: Read, Grep, Glob, Write, Edit, Bash(gh api:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(gh repo view:*), Bash(git remote:*), Bash(git add:*), Bash(git commit:*), Bash(git push), Bash(git rev-parse:*), Bash(git log:*)
+metadata:
+  context: same
+  agent: general-purpose
 ---
 
 # Triage

--- a/plugin/skills/bmad-ux/SKILL.md
+++ b/plugin/skills/bmad-ux/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: bmad-ux
 description: Experience Designer — Designs UI/UX, creates wireframes, maps user journeys. Use when UI design decisions are needed or to review existing UX.
-context: fork
-agent: Plan
 allowed-tools: Read, Grep, Glob
+metadata:
+  context: fork
+  agent: Plan
 ---
 
 # Experience Designer


### PR DESCRIPTION
## Summary
- Move `context` and `agent` fields into `metadata:` block in all 14 SKILL.md files to match the format required by the marketplace validator (`skills-ref`)
- Update `marketplace.json` description from old persona names to holacracy roles

## Context
PR [Luscii/claude-marketplace#7](https://github.com/Luscii/claude-marketplace/pull/7) (merged) required this frontmatter restructure to pass CI validation. The change was applied in the marketplace repo but never back-ported to this source repo, leaving 15 files permanently dirty.

## Test plan
- [ ] Verify SKILL.md frontmatter matches marketplace format (`metadata.context`, `metadata.agent`)
- [ ] Verify `marketplace.json` description uses holacracy roles
- [ ] Confirm plugin loads correctly via `claude --plugin-dir ./plugin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)