### PR TITLE
fix: code-review skill requires manual approval at every step

### DIFF
--- a/plugin/skills/bmad-code-review/SKILL.md
+++ b/plugin/skills/bmad-code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bmad-code-review
 description: "Code Review — Multi-agent PR review with CLAUDE.md compliance. Use on any open pull request."
-allowed-tools: Read, Grep, Glob, Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(git rev-parse:*), Bash(git log:*), Bash(git blame:*)
+allowed-tools: Read, Grep, Glob, Task, Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(git rev-parse:*), Bash(git log:*), Bash(git blame:*), Bash(git show:*), Bash(mkdir:*)
 metadata:
   context: same
   agent: general-purpose


### PR DESCRIPTION
## Summary
- Add `Task` to `allowed-tools` so subagent launches don't require manual confirmation
- Add `Bash(git show:*)` and `Bash(mkdir:*)` for branch comparison and output directory creation

## Context
The code review workflow launches ~10 subagents (eligibility, standards, summary, 5 parallel reviewers, confidence scoring) plus uses `git show` and `mkdir`. None of these were pre-approved, forcing the user to manually confirm every single step of an otherwise autonomous workflow.

## Test plan
- [ ] Run `/bmad-code-review` on an open PR and verify it completes without manual approval prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)