### PR TITLE
docs: clarify CLAUDE.md conventions from code review learnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ There is no build step, no tests, no CI. This is a pure Markdown plugin.
 
 ## SKILL.md Format
 
-Every role skill follows this structure:
+Every role skill follows this structure (utilities may omit sections like Domain-Specific Behavior or use inline Handoff):
 
 **YAML Frontmatter:**
 
@@ -93,7 +93,7 @@ metadata:
 - **Dependencies are optional**: All dependencies are declared in `deps-manifest.yaml`. `bmad-init` detects missing deps and offers installation. Roles degrade gracefully when dependencies are missing
 - **Templates live in resources**: Document templates go in `plugin/resources/templates/docs/` or `plugin/resources/templates/software/`
 - **Template variants**: Template variants use `-{technology}` suffix (e.g., `-swift`, `-node`). Technology is detected from marker files by `bmad-docs`, distinct from the 4-domain model used by other roles. Base templates are always language-agnostic
-- **Domain-agnostic core**: Skills must NOT name-drop specific MCP tools (Cupertino, SwiftUI Expert, etc.) — use "Domain-specific tools" generically. Domain-specific deps live only in `deps-manifest.yaml`
+- **Domain-agnostic core**: Skills must NOT name-drop domain-specific MCP tools (Cupertino, SwiftUI Expert, etc.) in their main body — use "Domain-specific tools" generically. Domain-specific deps live only in `deps-manifest.yaml`. Exception: the `## MCP Integration` section may name cross-domain tools (Linear, claude-mem) that all roles use
 - **Skill suggestions via deps-manifest**: Domain-specific skill suggestions use the `suggest_in` field in `deps-manifest.yaml`, mapping role names to contextual suggestion text. Roles read this field generically — never hardcode skill names in SKILL.md files. To add suggestions for a new domain, add `suggest_in` entries to deps-manifest only
 - **Scripts mirror deps-manifest**: `install-deps.sh` and `update-deps.sh` have hardcoded parallel arrays — they do NOT parse `deps-manifest.yaml`. Any dep added to the manifest MUST also be added to both scripts
 - **Version bump**: After feature work, update `version` in `plugin/.claude-plugin/plugin.json` before pushing
@@ -108,3 +108,4 @@ metadata:
 - **Role vs utility skills**: 8 of the 15 skills are holacracy roles. The rest (greenfield, sprint, code-review, triage, tdd, init, shard) are orchestrators or utilities — they coordinate roles but aren't roles themselves
 - **marketplace.json is separate from plugin.json**: `plugin.json` is the plugin manifest; `marketplace.json` is for the Claude plugin marketplace listing
 - **Output location**: BMAD never writes to the project directory. All outputs go to `~/.claude/bmad/projects/<project>/`. If a role writes to the repo, that's a bug
+- **Marketplace version sync**: After bumping `plugin.json` version and merging to main, also update `marketplace.json` version AND sync to Luscii/claude-marketplace. Three places must match: `plugin.json`, `marketplace.json`, and the marketplace repo copy

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ These run multi-step workflows, guiding you through each phase with decision poi
 | Command | What it does |
 |---|---|
 | `/bmad:bmad-init` | Sets up BMAD for your current project. Run this once per project. Checks for optional tools and offers to install them. |
+| `/bmad:bmad-tdd` | Enforces strict red-green-refactor TDD cycle. Write a failing test, make it pass, refactor. Used standalone or as sub-workflow of the Implementer |
 | `/bmad:bmad-shard` | Splits large documents into smaller pieces (called "shards") so roles can work with just the part they need — reduces token usage by ~90% |
 | `/bmad:bmad` | Shows project status: what phase you're in, what's been done, and what roles are available |
 
@@ -144,6 +145,7 @@ Built-in safety checks prevent the workflow from advancing when something isn't 
 
 - **Security Block**: The greenfield orchestrator won't move to implementation if critical security issues are found
 - **QA Reject Gate**: If the Quality Guardian rejects the implementation, the workflow sends it back to the Implementer for fixes
+- **TDD Compliance**: The Quality Guardian verifies commit history follows the `test(red):` → `feat(green):` → `refactor:` pattern. Hard enforcement blocks merge; soft enforcement warns only
 - **Completeness Check**: The orchestrator verifies output files exist before moving to the next step
 
 ### Context Sharding
@@ -200,7 +202,7 @@ Drop a `.md` in `plugin/resources/templates/docs/` or `software/`.
 
 ### New Feature
 ```
-Scope Clarifier → Prioritizer → [Experience Designer] → Architecture Owner → [Security] → [Facilitator] → Implementer → Quality Guardian
+Scope Clarifier → Prioritizer → [Experience Designer] → Architecture Owner → [Security] → [Facilitator] → Implementer (with TDD) → Quality Guardian
 ```
 Steps in brackets are optional.
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -22,7 +22,7 @@ If you just want to tweak how BMAD works for your project, here are the most com
 | **Role behavior** | Role definitions | `plugin/skills/bmad-<name>/SKILL.md` | Edit SKILL.md |
 | **Templates** | Document templates | `plugin/resources/templates/` | Drop .md file |
 | **New role** | Add a circle member | `plugin/skills/bmad-<name>/SKILL.md` | Create directory + file |
-| **Code review** | PR review with CLAUDE.md compliance | `/bmad-code-review <PR>` | Invoke on any open PR |
+| **Code review** | PR review with CLAUDE.md compliance | `/bmad:bmad-code-review <PR>` | Invoke on any open PR |
 
 ---
 
@@ -53,6 +53,13 @@ agents:
   bmad-impl:
     extra_instructions: |
       Follow project coding standards and existing conventions.
+
+# TDD (Test-Driven Development)
+# Enabled by default. The Implementer enforces red-green-refactor via /bmad-tdd.
+# The Quality Guardian verifies TDD compliance in commit history.
+tdd:
+  enabled: true           # Set to false to disable TDD workflow
+  enforcement: hard       # hard = QA blocks on violation; soft = QA warns only
 ```
 
 See `plugin/resources/templates/config-example.yaml` for a full example with all available options.
@@ -68,9 +75,10 @@ See `plugin/resources/templates/config-example.yaml` for a full example with all
 ---
 name: bmad-<name>
 description: "<Role Name> — <One-line purpose>. <When to use>."
-context: fork
-agent: general-purpose
 allowed-tools: Read, Grep, Glob, Bash
+metadata:
+  context: fork            # fork = isolated subagent | same = main conversation
+  agent: general-purpose   # Explore, Plan, qa, or general-purpose
 ---
 
 # <Role Name>

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -97,7 +97,7 @@ The greenfield command runs the entire process from start to finish, with you ma
 /bmad:bmad-greenfield
 ```
 
-This walks through: Scope Clarifier (requirements) → Prioritizer (product plan) → Experience Designer (design) → Architecture Owner (architecture) → Facilitator (sprint planning) → Implementer (implementation) → Quality Guardian (testing). You can skip steps that don't apply.
+This walks through: Scope Clarifier (requirements) → Prioritizer (product plan) → Experience Designer (design) → Architecture Owner (architecture) → Facilitator (sprint planning) → Implementer (implementation with TDD) → Quality Guardian (testing + TDD compliance). You can skip steps that don't apply.
 
 ## Available commands
 
@@ -117,6 +117,7 @@ Every command starts with `/bmad:`. Just type it and press Enter.
 | `/bmad:bmad-sprint` | Run a sprint planning session |
 | `/bmad:bmad-code-review` | Review a pull request |
 | `/bmad:bmad-triage` | Handle review feedback on a pull request |
+| `/bmad:bmad-tdd` | Enforce test-driven development (red-green-refactor cycle) |
 | `/bmad:bmad-shard` | Split large documents into smaller pieces (saves time and cost) |
 | `/bmad:bmad-init` | Set up BMAD for your current project (run once) |
 | `/bmad:bmad` | See project status and what's been done |

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -11,7 +11,7 @@ This guide covers migrating from the original BMAD-Setup (global slash commands 
 | `~/.claude/commands/bmad-init.md` | Plugin skill: `/bmad:bmad-init` |
 | `~/.claude/commands/bmad-remove.md` | Not needed (zero footprint by default) |
 | `~/Documents/BMAD-Setup/soul.md` | `plugin/resources/soul.md` |
-| `~/Documents/BMAD-Setup/bmad-section-template.md` | Distributed across 14 SKILL.md files |
+| `~/Documents/BMAD-Setup/bmad-section-template.md` | Distributed across 15 SKILL.md files |
 | Single conversation role-playing | Real role isolation (`context: fork`) |
 | No state persistence | `session-state.json` with pause/resume |
 | No quality gates | P0 blocks + QA reject gates |
@@ -164,6 +164,7 @@ mv ~/Documents/BMAD-Setup ~/Documents/BMAD-Setup-archived
 | `/bmad:bmad-doris` | `/bmad:bmad-docs` |
 | N/A | `/bmad:bmad-sprint` (sprint ceremony) |
 | N/A | `/bmad:bmad-shard` (context sharding) |
+| N/A | `/bmad:bmad-tdd` (TDD enforcement) |
 | N/A | `/bmad:bmad` (status dashboard) |
 
 ## Key Improvements After Migration
@@ -175,3 +176,4 @@ mv ~/Documents/BMAD-Setup ~/Documents/BMAD-Setup-archived
 5. **Team adoption**: `claude plugin install` — no more copying files and editing paths
 6. **Extensibility**: Add a role = create a directory with SKILL.md. Done.
 7. **Holacracy alignment**: Roles have purposes and accountabilities, not personas
+8. **TDD by default**: Red-green-refactor cycle enforced by the Implementer, verified by the Quality Guardian

--- a/plugin/commands/bmad.md
+++ b/plugin/commands/bmad.md
@@ -54,6 +54,7 @@ Review:
   /bmad-triage      — Handle review feedback
 
 Utilities:
+  /bmad-tdd   — TDD red-green-refactor enforcer
   /bmad-init  — Set up BMAD for this project
   /bmad-shard — Split large docs for faster processing
 
@@ -81,6 +82,13 @@ Active workflow details:
 ```
 Active workflow: <greenfield/sprint/none>
 Completed steps: <list or N/A>
+```
+
+TDD configuration:
+```
+TDD:
+  Enabled:     <true/false from config.yaml, default: true>
+  Enforcement: <hard/soft from config.yaml, default: hard>
 ```
 
 Check dependency versions: Read `~/.claude/plugins/installed_plugins.json` and check system binaries to show current versions.


### PR DESCRIPTION
## Summary
- Clarify that SKILL.md 8-section format applies to roles; utilities may deviate
- Refine domain-agnostic core rule: MCP Integration sections may name cross-domain tools (Linear, claude-mem)
- Add marketplace version sync gotcha (plugin.json + marketplace.json + Luscii repo must match)

## Context
Learnings from the code review of PR #6 (TDD methodology). The review agents flagged false positives due to ambiguous CLAUDE.md conventions.

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Verify no contradictions with existing skill files

🤖 Generated with [Claude Code](https://claude.com/claude-code)