### PR TITLE
fix: documentation sync, marketplace v0.4.0, and code-review ordering

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,9 @@
   "plugins": [
     {
       "name": "bmad",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "source": "./plugin",
-      "description": "8 holacracy roles for structured development workflows with quality gates and full customization"
+      "description": "15 skills (8 holacracy roles + 7 utilities) with structured workflows, quality gates, TDD enforcement, and full customization"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,11 @@ Multi-agent development workflow plugin for Claude Code. 15 skills (8 holacracy 
 ## Project Structure
 
 ```
+.claude-plugin/
+└── marketplace.json                    # Marketplace listing metadata
 plugin/
 ├── .claude-plugin/
-│   ├── plugin.json                     # Plugin manifest (name, version, author)
-│   └── marketplace.json                # Marketplace listing metadata
+│   └── plugin.json                     # Plugin manifest (name, version, author)
 ├── commands/
 │   └── bmad.md                         # /bmad status dashboard command
 ├── resources/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,12 +101,13 @@ metadata:
 - **Do not touch for neutralization**: `deps-manifest.yaml`, `bmad-init/SKILL.md`, and `bmad-triage/SKILL.md` contain domain-specific content by design (installer, multi-domain tables). These are correct patterns, not iOS bias
 - **docs/MIGRATION.md**: Contains intentional persona name references (Mary, Winston, etc.) for migration mapping — do not remove
 - **TDD enabled by default**: TDD (red-green-refactor) is on by default. `bmad-impl` invokes `/bmad-tdd` for each implementation unit. `bmad-qa` verifies TDD compliance via commit history (`test(red):` → `feat(green):` → `refactor:`). When the workflow doesn't involve testable code, `bmad-impl` prompts to disable for the session. Permanent opt-out via `tdd.enabled: false` in config.yaml. Enforcement level configurable: `hard` (default, QA blocks) or `soft` (QA warns)
+- **Code review requires a PR**: `/bmad-code-review` needs an open pull request. Roles must not suggest it before commit → push → PR creation. The correct handoff order is: impl → qa → commit → push → create PR → code-review
 - **Holacracy alignment**: Roles have purposes and accountabilities, not personas. Communication references roles, never personal names. External communication uses team voice, not role voice
 
 ## Gotchas
 
 - **Marketplace frontmatter validation**: The Luscii marketplace CI (`skills-ref`) only allows `name`, `description`, `allowed-tools`, `compatibility`, `license`, and `metadata` as top-level frontmatter fields. `context` and `agent` must go inside `metadata:`. Keep source repo in sync with marketplace
 - **Role vs utility skills**: 8 of the 15 skills are holacracy roles. The rest (greenfield, sprint, code-review, triage, tdd, init, shard) are orchestrators or utilities — they coordinate roles but aren't roles themselves
-- **marketplace.json is separate from plugin.json**: `plugin.json` is the plugin manifest; `marketplace.json` is for the Claude plugin marketplace listing
+- **marketplace.json is separate from plugin.json**: `plugin.json` is at `plugin/.claude-plugin/`; `marketplace.json` is at root `.claude-plugin/` (outside the plugin directory). They serve different purposes — plugin manifest vs marketplace listing
 - **Output location**: BMAD never writes to the project directory. All outputs go to `~/.claude/bmad/projects/<project>/`. If a role writes to the repo, that's a bug
 - **Marketplace version sync**: After bumping `plugin.json` version and merging to main, also update `marketplace.json` version AND sync to Luscii/claude-marketplace. Three places must match: `plugin.json`, `marketplace.json`, and the marketplace repo copy

--- a/plugin/resources/deps-manifest.yaml
+++ b/plugin/resources/deps-manifest.yaml
@@ -1,6 +1,7 @@
 # BMAD — Dependency Manifest
 # Single source of truth for all optional dependencies.
-# Read by: install-deps.sh, update-deps.sh, bmad-init, bmad-arch, bmad-impl, bmad-qa.
+# Reference for: install-deps.sh, update-deps.sh, bmad-init, bmad-arch, bmad-impl, bmad-qa.
+# NOTE: Shell scripts do not parse this file; keep their hardcoded registries in sync with this manifest.
 #
 # Override per-project in ~/.claude/bmad/projects/<project>/config.yaml
 # under the "dependencies:" key.

--- a/plugin/skills/bmad-code-review/SKILL.md
+++ b/plugin/skills/bmad-code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bmad-code-review
 description: "Code Review — Multi-agent PR review with CLAUDE.md compliance. Use on any open pull request."
-allowed-tools: Read, Grep, Glob, Task, Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(git rev-parse:*), Bash(git log:*), Bash(git blame:*), Bash(git show:*), Bash(mkdir:*)
+allowed-tools: Read, Grep, Glob, Task, Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(git rev-parse:*), Bash(git log:*), Bash(git blame:*), Bash(git show:*), Bash(mkdir ~/.claude/bmad/*)
 metadata:
   context: same
   agent: general-purpose

--- a/plugin/skills/bmad-docs/SKILL.md
+++ b/plugin/skills/bmad-docs/SKILL.md
@@ -51,7 +51,7 @@ After the user selects a template, check for technology-specific variants:
    - `go.mod` → `go`
    - `Cargo.toml` → `rust`
 2. Check if a variant exists: `{template-name}-{technology}.md` (e.g., `module-architecture-swift.md`)
-3. Check `config.yaml` for a `templates:` override (e.g., `module-architecture: module-architecture-swift`)
+3. Check `~/.claude/bmad/projects/{project}/config.yaml` for a `templates:` override (e.g., `module-architecture: module-architecture-swift`)
 4. Priority: config override > technology variant > base template
 5. If a variant is selected, inform the user: "Using {variant} template for {technology} project."
 6. If no technology match or no variant file exists, use the base template.

--- a/plugin/skills/bmad-greenfield/SKILL.md
+++ b/plugin/skills/bmad-greenfield/SKILL.md
@@ -168,9 +168,10 @@ After completion, type one of:
 | 6* | **Facilitator** | Sprint planning | PRD + Architecture | `facilitate/sprint-plan.md` |
 | 7 | **Implementer** | Implement | Architecture + PRD | Code in repo |
 | 8 | **Quality Guardian** | Test & validate | Requirements + Code | `qa/test-report.md` |
-| 9 | **Code Review** | PR review with CLAUDE.md compliance | PR branch + CLAUDE.md | `code-review/pr-{n}.md` |
 
 *Optional steps
+
+**Post-workflow** (after PR is created): Run `/bmad-code-review <PR>` for multi-agent review with CLAUDE.md compliance.
 
 ### User Command Handling
 
@@ -305,7 +306,9 @@ When all steps are completed:
    ~/.claude/bmad/projects/{project}/output/
 
    ## Next Steps
-   - [ ] Run `/bmad-code-review` for PR review with CLAUDE.md compliance
+   - [ ] Commit and push changes
+   - [ ] Create a pull request
+   - [ ] Run `/bmad-code-review <PR>` for multi-agent review with CLAUDE.md compliance
    - [ ] Merge to main branch
    - [ ] Update Linear issues
    ```

--- a/plugin/skills/bmad-impl/SKILL.md
+++ b/plugin/skills/bmad-impl/SKILL.md
@@ -111,7 +111,7 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
    - Tests pass
    - No obvious issues or regressions
 
-7. **Code Review**: If changes are on a PR branch, recommend running `/bmad-code-review` for multi-agent review with CLAUDE.md compliance checks. If a `CLAUDE.md` exists in the repo root, verify your implementation follows its standards before handoff.
+7. **CLAUDE.md compliance**: If a `CLAUDE.md` exists in the repo root, verify your implementation follows its standards before handoff.
 
 8. **Save implementation notes** to: `~/.claude/bmad/projects/$PROJECT_NAME/output/impl/implementation-notes-{date}.md`
 
@@ -123,7 +123,7 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
 10. **Handoff**:
    > **Implementer — Complete.**
    > Output saved to: `~/.claude/bmad/projects/{project}/output/impl/`
-   > Next suggested role: `/bmad-qa` for testing and validation, or `/bmad-code-review` for multi-agent PR review with CLAUDE.md compliance.
+   > Next suggested role: `/bmad-qa` for testing and validation.
 
 ## BMAD Principles
 - Follow the design: don't invent solutions different from those architected

--- a/plugin/skills/bmad-qa/SKILL.md
+++ b/plugin/skills/bmad-qa/SKILL.md
@@ -163,20 +163,18 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
       - `tdd.enforcement: hard` (default) + any FAIL → verdict = **REJECT** (P0: TDD cycle violated)
       - `tdd.enforcement: soft` + any FAIL → add P1 warning, do not override existing verdict
 
-6. **Code Review Gate**: If verdict is PASS or CONDITIONAL PASS and changes are on a PR branch, automatically recommend `/bmad-code-review` for multi-agent PR review with CLAUDE.md compliance checks before merge.
+6. **Save** to `~/.claude/bmad/projects/$PROJECT_NAME/output/qa/test-report-{date}.md`
 
-7. **Save** to `~/.claude/bmad/projects/$PROJECT_NAME/output/qa/test-report-{date}.md`
-
-8. **MCP Integration** (if available):
+7. **MCP Integration** (if available):
    - **Linear**: Link test results to issues, comment on verification outcomes
    - **claude-mem**: Search for past test patterns. Save test strategy decisions at completion.
 
-9. **Handoff**:
+8. **Handoff**:
    > **Quality Guardian — Complete.**
    > Verdict: **{PASS/CONDITIONAL PASS/REJECT}**
    > Output saved to: `~/.claude/bmad/projects/{project}/output/qa/`
    > {If REJECT: "P0 issues must be resolved. Run `/bmad-impl` to fix."}
-   > {If PASS: "Ready for merge. Run `/bmad-code-review` for PR review with CLAUDE.md compliance, then merge."}
+   > {If PASS: "Ready for merge. Commit, push, and create a PR. Then run `/bmad-code-review <PR>` for multi-agent review with CLAUDE.md compliance."}
 
 ## BMAD Principles
 - Data over opinions: run tests, measure coverage, report facts


### PR DESCRIPTION
## Summary

- Sync all documentation (README, CUSTOMIZATION, GETTING-STARTED, MIGRATION) with bmad-tdd and v0.4.0 changes
- Update marketplace.json version from 0.3.0 to 0.4.0 and fix description
- Fix CLAUDE.md project structure to show marketplace.json at correct root location
- Fix premature `/bmad-code-review` suggestions in bmad-impl, bmad-qa, and bmad-greenfield (requires open PR)
- Address PR #8 marketplace review feedback (deps header, config path, mkdir scope)
- Add CLAUDE.md conventions for code-review ordering and marketplace.json location

## Test plan

- [ ] Verify `plugin.json` and `marketplace.json` versions both show 0.4.0
- [ ] Verify CLAUDE.md project structure matches actual file layout
- [ ] Verify bmad-impl handoff only suggests `/bmad-qa`, not `/bmad-code-review`
- [ ] Verify bmad-qa handoff mentions "create a PR" before suggesting code-review
- [ ] Verify bmad-greenfield completion next steps include commit → push → create PR → code-review
- [ ] Load plugin locally with `claude --plugin-dir ./plugin` and verify skills load

🤖 Generated with [Claude Code](https://claude.com/claude-code)