### PR TITLE
feat: add Security Guardian role (v0.5.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,9 @@
   "plugins": [
     {
       "name": "bmad",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "source": "./plugin",
-      "description": "15 skills (8 holacracy roles + 7 utilities) with structured workflows, quality gates, TDD enforcement, and full customization"
+      "description": "16 skills (9 holacracy roles + 7 utilities) with structured workflows, quality gates, TDD enforcement, security audits, and full customization"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,115 +1,50 @@
 # BMAD Plugin
 
-Multi-agent development workflow plugin for Claude Code. 16 skills (9 holacracy roles + 7 utilities) with structured workflows, quality gates, TDD enforcement, security audits, and full customization.
+Pure Markdown plugin for Claude Code. 16 skills (9 holacracy roles + 7 utilities). No build, no tests, no CI.
 
-## Project Structure
-
-```
-.claude-plugin/
-└── marketplace.json                    # Marketplace listing metadata
-plugin/
-├── .claude-plugin/
-│   └── plugin.json                     # Plugin manifest (name, version, author)
-├── commands/
-│   └── bmad.md                         # /bmad status dashboard command
-├── resources/
-│   ├── soul.md                         # Team principles — loaded by all roles
-│   ├── deps-manifest.yaml              # Dependency registry (single source of truth)
-│   ├── scripts/
-│   │   ├── install-deps.sh             # First-time dependency installer
-│   │   └── update-deps.sh              # Dependency updater
-│   └── templates/
-│       ├── config-example.yaml         # Per-project config template
-│       ├── docs/                       # Document templates (ADR, module arch, UI)
-│       └── software/                   # Software templates (PRD, architecture, security)
-└── skills/
-    ├── bmad-scope/SKILL.md             # Scope Clarifier
-    ├── bmad-arch/SKILL.md              # Architecture Owner
-    ├── bmad-impl/SKILL.md              # Implementer
-    ├── bmad-qa/SKILL.md                # Quality Guardian
-    ├── bmad-ux/SKILL.md                # Experience Designer
-    ├── bmad-prioritize/SKILL.md        # Prioritizer
-    ├── bmad-facilitate/SKILL.md        # Facilitator
-    ├── bmad-docs/SKILL.md              # Documentation Steward
-    ├── bmad-security/SKILL.md          # Security Guardian
-    ├── bmad-code-review/SKILL.md       # Multi-agent PR code review
-    ├── bmad-triage/SKILL.md            # PR review comment triage
-    ├── bmad-greenfield/SKILL.md        # Full workflow orchestrator
-    ├── bmad-sprint/SKILL.md            # Sprint planning orchestrator
-    ├── bmad-tdd/SKILL.md               # TDD red-green-refactor enforcer
-    ├── bmad-init/SKILL.md              # Project initialization
-    └── bmad-shard/SKILL.md             # Context sharding utility
-docs/
-├── CUSTOMIZATION.md                    # 8-layer customization guide
-├── GETTING-STARTED.md                  # Quick-start guide for new users
-└── MIGRATION.md                        # Migration from old BMAD-Setup
-```
-
-## Development
-
-Test changes by loading the plugin locally:
+## Dev
 
 ```bash
 claude --plugin-dir ./plugin
 ```
 
-There is no build step, no tests, no CI. This is a pure Markdown plugin.
+## Layout
 
-## SKILL.md Format
-
-Every role skill follows this structure (utilities may omit sections like Domain-Specific Behavior or use inline Handoff):
-
-**YAML Frontmatter:**
-
-```yaml
----
-name: bmad-<role>
-description: "<Role Name> — <Purpose>."
-allowed-tools: Read, Grep, Glob, Bash
-metadata:
-  context: fork        # fork = isolated subagent | same = main conversation thread
-  agent: Explore       # Explore, Plan, qa, or general-purpose
----
+```
+.claude-plugin/marketplace.json        # Marketplace listing (root, outside plugin/)
+plugin/.claude-plugin/plugin.json      # Plugin manifest (name, version)
+plugin/commands/bmad.md                # /bmad dashboard
+plugin/resources/soul.md               # Shared principles — every role loads this
+plugin/resources/deps-manifest.yaml    # Dependency registry (source of truth)
+plugin/resources/scripts/              # install-deps.sh, update-deps.sh
+plugin/resources/templates/{docs,software}/ # Output templates
+plugin/skills/bmad-*/SKILL.md          # 16 skills (see ls)
+docs/                                  # CUSTOMIZATION.md, GETTING-STARTED.md, MIGRATION.md
 ```
 
-**Markdown Body (in order):**
+## Rules
 
-1. Soul reference — link to `soul.md` principles
-2. Role description — 2-3 sentences defining the role's accountabilities
-3. Domain detection — how to detect software/business/personal/general
-4. Input prerequisites — what files/outputs to read before starting
-5. Domain-specific behavior — different instructions per domain
-6. Process — step-by-step execution instructions
-7. Handoff — completion message and next role recommendation
-8. BMAD principles — core tenets specific to this role
+**Naming**: `bmad-<lowercase>` everywhere — dirs, frontmatter, output paths.
 
-## Conventions
+**Context model**: `context: fork` for roles, `context: same` for orchestrators/interactive.
 
-- **Role naming**: `bmad-<lowercase-role>` everywhere (skill dirs, frontmatter, output dirs)
-- **Context model**: Use `context: fork` for roles (isolated execution). Use `context: same` for orchestrators and interactive workflows
-- **Domain detection**: Roles detect project type by looking for marker files (Package.swift, package.json, etc.) and adjust behavior accordingly
-- **Quality gates**: P0 security blocks stop workflow before implementation. QA rejection loops back to the Implementer. Completeness checks verify outputs exist before advancing
-- **Zero project footprint**: All BMAD outputs go to `~/.claude/bmad/projects/<project>/`. Nothing is committed to the repo
-- **MCP tools are optional**: Roles check for MCP tools (Linear, claude-mem, and domain-specific servers) but degrade gracefully if absent
-- **Soul is mandatory**: Every role must reference and follow `plugin/resources/soul.md`
-- **Dependencies are optional**: All dependencies are declared in `deps-manifest.yaml`. `bmad-init` detects missing deps and offers installation. Roles degrade gracefully when dependencies are missing
-- **Templates live in resources**: Document templates go in `plugin/resources/templates/docs/` or `plugin/resources/templates/software/`
-- **Template variants**: Template variants use `-{technology}` suffix (e.g., `-swift`, `-node`). Technology is detected from marker files by `bmad-docs`, distinct from the 4-domain model used by other roles. Base templates are always language-agnostic
-- **Domain-agnostic core**: Skills must NOT name-drop domain-specific MCP tools (Cupertino, SwiftUI Expert, etc.) in their main body — use "Domain-specific tools" generically. Domain-specific deps live only in `deps-manifest.yaml`. Exception: the `## MCP Integration` section may name cross-domain tools (Linear, claude-mem) that all roles use
-- **Skill suggestions via deps-manifest**: Domain-specific skill suggestions use the `suggest_in` field in `deps-manifest.yaml`, mapping role names to contextual suggestion text. Roles read this field generically — never hardcode skill names in SKILL.md files. To add suggestions for a new domain, add `suggest_in` entries to deps-manifest only
-- **Scripts mirror deps-manifest**: `install-deps.sh` and `update-deps.sh` have hardcoded parallel arrays — they do NOT parse `deps-manifest.yaml`. Any dep added to the manifest MUST also be added to both scripts
-- **Version bump**: After feature work, update `version` in `plugin/.claude-plugin/plugin.json` before pushing
-- **Do not touch for neutralization**: `deps-manifest.yaml`, `bmad-init/SKILL.md`, and `bmad-triage/SKILL.md` contain domain-specific content by design (installer, multi-domain tables). These are correct patterns, not iOS bias
-- **docs/MIGRATION.md**: Contains intentional persona name references (Mary, Winston, etc.) for migration mapping — do not remove
-- **TDD enabled by default**: TDD (red-green-refactor) is on by default. `bmad-impl` invokes `/bmad-tdd` for each implementation unit. `bmad-qa` verifies TDD compliance via commit history (`test(red):` → `feat(green):` → `refactor:`). When the workflow doesn't involve testable code, `bmad-impl` prompts to disable for the session. Permanent opt-out via `tdd.enabled: false` in config.yaml. Enforcement level configurable: `hard` (default, QA blocks) or `soft` (QA warns)
-- **Security gate blocks implementation**: `/bmad-security` can issue a P0 SECURITY BLOCK that prevents `/bmad-impl` from proceeding in the greenfield workflow. The security audit output goes to `output/security/security-audit.md`
-- **Code review requires a PR**: `/bmad-code-review` needs an open pull request. Roles must not suggest it before commit → push → PR creation. The correct handoff order is: impl → qa → commit → push → create PR → code-review
-- **Holacracy alignment**: Roles have purposes and accountabilities, not personas. Communication references roles, never personal names. External communication uses team voice, not role voice
+**Zero footprint**: All outputs → `~/.claude/bmad/projects/<project>/`. Never write to the repo.
+
+**Domain-agnostic core**: Never name-drop domain-specific tools (Cupertino, SwiftUI Expert) in SKILL.md body. Domain deps live only in `deps-manifest.yaml` with `suggest_in` entries. Exception: `## MCP Integration` sections may name cross-domain tools (Linear, claude-mem).
+
+**Scripts mirror manifest**: `install-deps.sh` and `update-deps.sh` have hardcoded arrays — they do NOT parse `deps-manifest.yaml`. Any dep change must update both scripts AND the manifest.
+
+**Version bump**: After feature work, update version in `plugin.json`. After merge, sync `marketplace.json` AND Luscii/claude-marketplace. Three places must match.
+
+**Workflow order**: arch → security (P0 blocks impl) → impl → qa (REJECT loops to impl) → commit → push → PR → code-review. Never suggest `/bmad-code-review` before a PR exists.
+
+**TDD**: On by default. `bmad-impl` uses `/bmad-tdd` for red-green-refactor. `bmad-qa` verifies via commit history. Disable: `tdd.enabled: false` in config.yaml. Enforcement: `hard` (blocks) or `soft` (warns).
+
+**Holacracy**: Roles have purposes, not personas. Reference roles, not names. External comms use team voice.
 
 ## Gotchas
 
-- **Marketplace frontmatter validation**: The Luscii marketplace CI (`skills-ref`) only allows `name`, `description`, `allowed-tools`, `compatibility`, `license`, and `metadata` as top-level frontmatter fields. `context` and `agent` must go inside `metadata:`. Keep source repo in sync with marketplace
-- **Role vs utility skills**: 9 of the 16 skills are holacracy roles (including Security Guardian). The rest (greenfield, sprint, code-review, triage, tdd, init, shard) are orchestrators or utilities — they coordinate roles but aren't roles themselves
-- **marketplace.json is separate from plugin.json**: `plugin.json` is at `plugin/.claude-plugin/`; `marketplace.json` is at root `.claude-plugin/` (outside the plugin directory). They serve different purposes — plugin manifest vs marketplace listing
-- **Output location**: BMAD never writes to the project directory. All outputs go to `~/.claude/bmad/projects/<project>/`. If a role writes to the repo, that's a bug
-- **Marketplace version sync**: After bumping `plugin.json` version and merging to main, also update `marketplace.json` version AND sync to Luscii/claude-marketplace. Three places must match: `plugin.json`, `marketplace.json`, and the marketplace repo copy
+- **Marketplace frontmatter**: Only `name`, `description`, `allowed-tools`, `compatibility`, `license`, `metadata` allowed as top-level fields. `context`/`agent` go inside `metadata:`
+- **marketplace.json vs plugin.json**: Different files, different locations (root `.claude-plugin/` vs `plugin/.claude-plugin/`), different purposes
+- **Do not neutralize**: `deps-manifest.yaml`, `bmad-init`, `bmad-triage` contain domain-specific content by design
+- **MIGRATION.md**: Contains intentional persona names (Mary, Winston) for migration mapping

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # BMAD Plugin
 
-Multi-agent development workflow plugin for Claude Code. 15 skills (8 holacracy roles + 7 utilities) with structured workflows, quality gates, TDD enforcement, and full customization.
+Multi-agent development workflow plugin for Claude Code. 16 skills (9 holacracy roles + 7 utilities) with structured workflows, quality gates, TDD enforcement, security audits, and full customization.
 
 ## Project Structure
 
@@ -31,6 +31,7 @@ plugin/
     ├── bmad-prioritize/SKILL.md        # Prioritizer
     ├── bmad-facilitate/SKILL.md        # Facilitator
     ├── bmad-docs/SKILL.md              # Documentation Steward
+    ├── bmad-security/SKILL.md          # Security Guardian
     ├── bmad-code-review/SKILL.md       # Multi-agent PR code review
     ├── bmad-triage/SKILL.md            # PR review comment triage
     ├── bmad-greenfield/SKILL.md        # Full workflow orchestrator
@@ -101,13 +102,14 @@ metadata:
 - **Do not touch for neutralization**: `deps-manifest.yaml`, `bmad-init/SKILL.md`, and `bmad-triage/SKILL.md` contain domain-specific content by design (installer, multi-domain tables). These are correct patterns, not iOS bias
 - **docs/MIGRATION.md**: Contains intentional persona name references (Mary, Winston, etc.) for migration mapping — do not remove
 - **TDD enabled by default**: TDD (red-green-refactor) is on by default. `bmad-impl` invokes `/bmad-tdd` for each implementation unit. `bmad-qa` verifies TDD compliance via commit history (`test(red):` → `feat(green):` → `refactor:`). When the workflow doesn't involve testable code, `bmad-impl` prompts to disable for the session. Permanent opt-out via `tdd.enabled: false` in config.yaml. Enforcement level configurable: `hard` (default, QA blocks) or `soft` (QA warns)
+- **Security gate blocks implementation**: `/bmad-security` can issue a P0 SECURITY BLOCK that prevents `/bmad-impl` from proceeding in the greenfield workflow. The security audit output goes to `output/security/security-audit.md`
 - **Code review requires a PR**: `/bmad-code-review` needs an open pull request. Roles must not suggest it before commit → push → PR creation. The correct handoff order is: impl → qa → commit → push → create PR → code-review
 - **Holacracy alignment**: Roles have purposes and accountabilities, not personas. Communication references roles, never personal names. External communication uses team voice, not role voice
 
 ## Gotchas
 
 - **Marketplace frontmatter validation**: The Luscii marketplace CI (`skills-ref`) only allows `name`, `description`, `allowed-tools`, `compatibility`, `license`, and `metadata` as top-level frontmatter fields. `context` and `agent` must go inside `metadata:`. Keep source repo in sync with marketplace
-- **Role vs utility skills**: 8 of the 15 skills are holacracy roles. The rest (greenfield, sprint, code-review, triage, tdd, init, shard) are orchestrators or utilities — they coordinate roles but aren't roles themselves
+- **Role vs utility skills**: 9 of the 16 skills are holacracy roles (including Security Guardian). The rest (greenfield, sprint, code-review, triage, tdd, init, shard) are orchestrators or utilities — they coordinate roles but aren't roles themselves
 - **marketplace.json is separate from plugin.json**: `plugin.json` is at `plugin/.claude-plugin/`; `marketplace.json` is at root `.claude-plugin/` (outside the plugin directory). They serve different purposes — plugin manifest vs marketplace listing
 - **Output location**: BMAD never writes to the project directory. All outputs go to `~/.claude/bmad/projects/<project>/`. If a role writes to the repo, that's a bug
 - **Marketplace version sync**: After bumping `plugin.json` version and merging to main, also update `marketplace.json` version AND sync to Luscii/claude-marketplace. Three places must match: `plugin.json`, `marketplace.json`, and the marketplace repo copy

--- a/docs/plans/2026-02-24-bmad-security-design.md
+++ b/docs/plans/2026-02-24-bmad-security-design.md
@@ -1,0 +1,91 @@
+# Design: Security Guardian (`bmad-security`)
+
+**Date**: 2026-02-24
+**Status**: Approved
+**Based on**: darthpelo/bmad-holacracy `bmad-security`, adapted to our conventions
+
+## Overview
+
+Add a Security Guardian role to the BMAD plugin, fully integrated into the greenfield workflow and code review pipeline. Two domains: software (STRIDE, OWASP Top 10) and business (GDPR, compliance, vendor risk). Single template with conditional sections.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Domains | Software + Business (no personal) | Professional focus |
+| Code review integration | Add Agent #6 Security Scan | Security in both pre-impl and PR review |
+| Output directory | `output/security/` (dedicated) | Clean separation per role |
+| Template strategy | Single template, conditional sections | Simpler to maintain |
+
+## New Skill: `plugin/skills/bmad-security/SKILL.md`
+
+- Holacracy role: Security Guardian
+- Frontmatter: `context: fork`, `agent: qa`
+- Soul reference, domain detection, config override (standard)
+- Domain-agnostic core (no MCP tool names in body)
+
+### Software Domain
+
+- STRIDE threat model (Spoofing, Tampering, Repudiation, Info Disclosure, DoS, Elevation)
+- OWASP Top 10 assessment
+- Platform-specific security (detected from marker files)
+- Vulnerability analysis with P0-P3 severity
+- Remediation roadmap
+
+### Business Domain
+
+- Regulatory compliance (GDPR, CCPA, industry-specific)
+- Data governance assessment
+- Vendor risk analysis
+- Data breach response evaluation
+- Compliance gaps and remediation
+
+### Security Gate
+
+```
+arch -> security (P0 check) -> impl
+          |
+          +-- P0 found -> SECURITY BLOCK -> fix -> re-run
+          +-- P1 found -> PASS with warnings -> proceed
+          +-- P2/P3    -> PASS -> proceed
+```
+
+### Handoff Messages
+
+- SECURITY BLOCK: "P0 critical issues found. MUST fix before `/bmad-impl`."
+- PASS with warnings: "P1 issues found. Proceed to `/bmad-impl`; fix P1 in parallel."
+- PASS: "No blocking issues. Proceed to `/bmad-impl`."
+
+## Files to Create
+
+| File | Description |
+|------|-------------|
+| `plugin/skills/bmad-security/SKILL.md` | New Security Guardian skill |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `plugin/skills/bmad-greenfield/SKILL.md` | Update Gate 1 to read from `output/security/`. Add `security` to mkdir. Update Role Sequence table |
+| `plugin/skills/bmad-code-review/SKILL.md` | Add Agent #6 — Security Scan (OWASP in diff) |
+| `plugin/skills/bmad-arch/SKILL.md` | Add security handoff suggestion |
+| `plugin/resources/templates/software/security-audit.md` | Add conditional business sections (compliance, data governance) |
+| `plugin/.claude-plugin/plugin.json` | Version bump to 0.5.0 |
+| `CLAUDE.md` | Add bmad-security to structure, update skill count to 16, document conventions |
+
+## Code Review Agent #6 — Security Scan
+
+Scans the PR diff for:
+- Injection patterns (SQL, command, XSS)
+- Auth/authz issues (missing checks, hardcoded secrets)
+- Crypto issues (weak algorithms, plaintext secrets)
+- Data exposure (PII logging, verbose errors)
+
+Same scoring (0-100) and threshold (80) as other agents.
+
+## What Does NOT Change
+
+- `bmad-qa` — unchanged, does not handle security
+- `deps-manifest.yaml` — no new dependencies
+- Zero project footprint — outputs to `~/.claude/bmad/`
+- Domain-agnostic core — no domain-specific MCP tools in skill body

--- a/docs/plans/2026-02-24-bmad-security-impl.md
+++ b/docs/plans/2026-02-24-bmad-security-impl.md
@@ -1,0 +1,564 @@
+# Security Guardian Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a Security Guardian role (`bmad-security`) fully integrated into the greenfield workflow, code review pipeline, and quality gates.
+
+**Architecture:** New SKILL.md following existing role conventions (soul ref, domain detection, config override, P0-P3 gates). Two domains: software (STRIDE/OWASP) and business (GDPR/compliance). Integrates into greenfield as optional step, adds Agent #6 to code review.
+
+**Tech Stack:** Pure Markdown plugin — no build step, no tests, no CI.
+
+---
+
+### Task 1: Create `bmad-security/SKILL.md`
+
+**Files:**
+- Create: `plugin/skills/bmad-security/SKILL.md`
+- Reference (read-only): `plugin/skills/bmad-arch/SKILL.md` (template for role structure)
+- Reference (read-only): `plugin/resources/templates/software/security-audit.md` (output template)
+
+**Step 1: Create the skill directory**
+
+```bash
+mkdir -p plugin/skills/bmad-security
+```
+
+**Step 2: Write SKILL.md**
+
+Create `plugin/skills/bmad-security/SKILL.md` with this exact content:
+
+```markdown
+---
+name: bmad-security
+description: "Security Guardian — Security audit, threat modeling, compliance checks. Use after architecture, before implementation."
+allowed-tools: Read, Grep, Glob, Bash
+metadata:
+  context: fork
+  agent: qa
+---
+
+# Security Guardian
+
+You energize the **Security Guardian** role in the BMAD circle. You identify vulnerabilities, model threats, and validate compliance — ensuring the team ships securely.
+
+## Soul
+
+Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
+Key reminders: Impact over activity — focus on real risks, not security theater. Speak up about vulnerabilities, even when inconvenient.
+
+## Your Role
+
+You are the security conscience of the team. You think in attack vectors, not features. You evaluate threats rigorously, prioritize real risks over theoretical ones, and only reach for complexity when simplicity leaves a gap. You document your findings so the Implementer can act on them. You respect the Architecture Owner's design but you will push back when it creates security debt.
+
+## Domain Detection
+
+Detect the project domain by analyzing files in the current directory:
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
+- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
+- **general**: default if no indicator found
+
+## Input Prerequisites
+
+Read from `~/.claude/bmad/projects/{project}/output/`:
+- Architecture: `arch/architecture.md` or `arch/operational-architecture.md`
+- Also useful: `scope/requirements.md`, `prioritize/PRD.md`
+- If architecture missing: "Architecture missing. Run `/bmad-arch` first."
+
+Also check for project config: `~/.claude/bmad/projects/{project}/config.yaml`
+- If `extra_instructions` for bmad-security exists, incorporate them
+
+## Domain-Specific Behavior
+
+### Software Development
+**Focus**: Threat modeling (STRIDE), OWASP Top 10, secure architecture, vulnerability assessment
+**Output filename**: `security-audit.md`
+**Activities**:
+- STRIDE threat model for each component (auth, API, DB, storage, etc.)
+- OWASP Top 10 assessment against the architecture
+- Platform-specific security checks (detected from marker files)
+- Vulnerability analysis with P0-P3 severity
+- Remediation roadmap prioritized by severity
+
+**Domain Skill Suggestions**:
+
+Check `${CLAUDE_PLUGIN_ROOT}/resources/deps-manifest.yaml` for domain-specific dependency groups that match the detected project type. For each dependency in a matching group that has a `suggest_in` entry for this role (`security`), suggest:
+
+> "Consider invoking `/<dep-id>` for <suggest_in text>"
+
+These are suggestions, not blocks — proceed with or without them. If a suggested skill is not installed, note: "Not installed. Run: `<install_command>` from deps-manifest."
+
+### Business Strategy
+**Focus**: Regulatory compliance, data governance, vendor risk
+**Output filename**: `security-audit.md`
+**Activities**:
+- Regulatory requirements assessment (GDPR, CCPA, industry-specific)
+- Data governance review (collection, storage, processing, retention)
+- Vendor risk analysis (third-party dependencies, data sharing)
+- Data breach response evaluation
+- Compliance gaps and remediation plan
+
+### Personal / General
+For personal or general domains, security audits are not applicable. Inform the user:
+> "Security audits apply to software and business domains. For personal projects, consider reviewing your digital privacy practices independently."
+
+## Process
+
+1. **Initialize output directory**:
+   ```bash
+   PROJECT_NAME=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
+   mkdir -p ~/.claude/bmad/projects/$PROJECT_NAME/output/security
+   ```
+
+2. **Read architecture and requirements**: Understand the system's attack surface
+
+3. **Scope the audit**: Determine what to audit based on domain:
+   - Software: system components, APIs, data stores, authentication, authorization
+   - Business: data handling, vendor relationships, regulatory requirements
+
+4. **Threat modeling** (software domain):
+   Apply STRIDE to each component identified in the architecture:
+   - **S**poofing: Can an attacker impersonate a user or service?
+   - **T**ampering: Can data be modified in transit or at rest?
+   - **R**epudiation: Can actions be denied without evidence?
+   - **I**nformation Disclosure: Can sensitive data leak?
+   - **D**enial of Service: Can the system be overwhelmed?
+   - **E**levation of Privilege: Can an attacker gain unauthorized access?
+
+5. **OWASP Top 10 check** (software domain):
+   Assess the architecture against each OWASP Top 10 category:
+   A01 Broken Access Control, A02 Cryptographic Failures, A03 Injection,
+   A04 Insecure Design, A05 Security Misconfiguration, A06 Vulnerable Components,
+   A07 Auth Failures, A08 Data Integrity Failures, A09 Logging Failures, A10 SSRF
+
+6. **Compliance check** (business domain):
+   - GDPR: data processing basis, consent, right to erasure, DPO
+   - CCPA: California consumer rights, opt-out, data sale
+   - Industry-specific: HIPAA (health), PCI DSS (payments), SOX (finance)
+
+7. **Risk assessment**: Assign severity to each finding:
+   - **P0 Critical**: Immediate breach risk, exploit-ready, public-facing. Fix within 24-48h
+   - **P1 High**: Significant risk, authenticated exploit path. Fix within 1 week
+   - **P2 Medium**: Moderate risk, defense-in-depth gap. Fix within 1 month
+   - **P3 Low**: Best practice deviation, minor config issue. Fix when convenient
+
+8. **Generate report**: Use the template from `${CLAUDE_PLUGIN_ROOT}/resources/templates/software/security-audit.md`. Write to `~/.claude/bmad/projects/$PROJECT_NAME/output/security/security-audit.md`
+
+9. **MCP Integration** (if available):
+   - **Linear**: Link security findings to issues, create P0/P1 issues for critical findings
+   - **claude-mem**: Search for past security patterns. Save key findings at completion.
+
+10. **Security Gate Decision**:
+
+Based on findings, determine the verdict:
+- If ANY **P0** finding → verdict is **SECURITY BLOCK**
+- If P1 but no P0 → verdict is **SECURITY PASS with warnings**
+- If only P2/P3 → verdict is **SECURITY PASS**
+
+11. **Handoff**:
+
+**If SECURITY BLOCK:**
+> **Security Guardian — BLOCKED (P0 critical issues).**
+> Output saved to: `~/.claude/bmad/projects/{project}/output/security/security-audit.md`
+> These MUST be fixed before implementation. Re-run `/bmad-security` after fixes.
+
+**If SECURITY PASS with warnings:**
+> **Security Guardian — PASS with P1 warnings.**
+> Output saved to: `~/.claude/bmad/projects/{project}/output/security/security-audit.md`
+> Proceed to `/bmad-impl`; fix P1 issues in parallel.
+
+**If SECURITY PASS:**
+> **Security Guardian — PASS.**
+> Output saved to: `~/.claude/bmad/projects/{project}/output/security/security-audit.md`
+> No blocking issues. Proceed to `/bmad-impl` for implementation.
+
+## BMAD Principles
+- Defense in depth: multiple layers of security, not single point of failure
+- Assume breach: design for "when" not "if" compromised
+- Impact over activity: focus on real risks, not security theater
+- Human-in-the-loop: ask for clarification if architecture is unclear, don't assume
+- Speak up: flag risks early and honestly, even when inconvenient
+```
+
+**Step 3: Commit**
+
+```bash
+git add plugin/skills/bmad-security/SKILL.md
+git commit -m "feat: add bmad-security skill (Security Guardian role)"
+```
+
+---
+
+### Task 2: Update security-audit template
+
+**Files:**
+- Modify: `plugin/resources/templates/software/security-audit.md`
+
+**Step 1: Edit the template**
+
+Replace the entire content of `plugin/resources/templates/software/security-audit.md` with:
+
+```markdown
+# Security Audit: {Feature/System Name}
+
+**Date**: {YYYY-MM-DD}
+**Auditor**: Security Guardian (BMAD)
+**Scope**: {What was audited}
+**Domain**: {software / business}
+
+---
+
+## Executive Summary
+
+**Risk Level**: {Critical / High / Medium / Low}
+**Critical Findings**: {count}
+**Verdict**: {SECURITY BLOCK / SECURITY PASS with warnings / SECURITY PASS}
+
+---
+
+<!-- SOFTWARE DOMAIN: Include STRIDE + OWASP sections -->
+
+## STRIDE Threat Model
+
+| Threat | Category | Component | Severity | Status |
+|---|---|---|---|---|
+| {Threat description} | Spoofing / Tampering / Repudiation / Info Disclosure / DoS / Elevation | {Component} | P0/P1/P2/P3 | Open / Mitigated |
+
+## OWASP Top 10 Check
+
+| # | Category | Status | Notes |
+|---|---|---|---|
+| A01 | Broken Access Control | Pass/Fail/N/A | {Notes} |
+| A02 | Cryptographic Failures | Pass/Fail/N/A | {Notes} |
+| A03 | Injection | Pass/Fail/N/A | {Notes} |
+| A04 | Insecure Design | Pass/Fail/N/A | {Notes} |
+| A05 | Security Misconfiguration | Pass/Fail/N/A | {Notes} |
+| A06 | Vulnerable Components | Pass/Fail/N/A | {Notes} |
+| A07 | Auth Failures | Pass/Fail/N/A | {Notes} |
+| A08 | Data Integrity Failures | Pass/Fail/N/A | {Notes} |
+| A09 | Logging Failures | Pass/Fail/N/A | {Notes} |
+| A10 | SSRF | Pass/Fail/N/A | {Notes} |
+
+## Platform-Specific Security
+
+- **{Platform security concern 1}**: {Assessment}
+- **{Platform security concern 2}**: {Assessment}
+
+<!-- BUSINESS DOMAIN: Include Compliance + Data Governance sections -->
+
+## Regulatory Compliance
+
+| Regulation | Applicable | Status | Gaps |
+|---|---|---|---|
+| GDPR | Yes/No | Compliant / Partial / Non-compliant | {Gaps} |
+| CCPA | Yes/No | Compliant / Partial / Non-compliant | {Gaps} |
+| {Industry-specific} | Yes/No | Compliant / Partial / Non-compliant | {Gaps} |
+
+## Data Governance
+
+- **Collection**: {What data, legal basis, consent mechanism}
+- **Storage**: {Where, encryption, retention policy}
+- **Processing**: {How, who has access, audit trail}
+- **Sharing**: {Third parties, data processing agreements}
+
+## Vendor Risk
+
+| Vendor | Data Shared | Risk Level | DPA in Place | Notes |
+|---|---|---|---|---|
+| {Vendor} | {Data types} | High/Medium/Low | Yes/No | {Notes} |
+
+<!-- ALL DOMAINS: Findings, Recommendations, Verdict -->
+
+---
+
+## Findings
+
+### P0 — Critical (Must fix before implementation)
+- {Finding or "None"}
+
+### P1 — High (Fix before release)
+- {Finding or "None"}
+
+### P2 — Medium (Fix in next sprint)
+- {Finding or "None"}
+
+### P3 — Low (Track for future)
+- {Finding or "None"}
+
+## Remediation Roadmap
+
+| Priority | Finding | Action | Owner | Timeline |
+|---|---|---|---|---|
+| P0 | {Finding} | {Action} | {Role} | Immediate |
+| P1 | {Finding} | {Action} | {Role} | This sprint |
+
+## Verdict
+
+**{SECURITY BLOCK / SECURITY PASS with warnings / SECURITY PASS}**
+
+{Summary statement}
+```
+
+**Step 2: Commit**
+
+```bash
+git add plugin/resources/templates/software/security-audit.md
+git commit -m "feat: extend security-audit template with business domain sections"
+```
+
+---
+
+### Task 3: Update greenfield orchestrator
+
+**Files:**
+- Modify: `plugin/skills/bmad-greenfield/SKILL.md:80-82` (mkdir line)
+- Modify: `plugin/skills/bmad-greenfield/SKILL.md:160-172` (Role Sequence table)
+- Modify: `plugin/skills/bmad-greenfield/SKILL.md:239-253` (Gate 1 security path)
+
+**Step 1: Add `security` to the mkdir command**
+
+In `plugin/skills/bmad-greenfield/SKILL.md`, find:
+```
+mkdir -p $BASE/output/{scope,arch,impl,qa,ux,prioritize,facilitate,docs,code-review}
+```
+Replace with:
+```
+mkdir -p $BASE/output/{scope,arch,impl,qa,ux,prioritize,facilitate,docs,code-review,security}
+```
+
+**Step 2: Update the Role Sequence table**
+
+Find the table at line ~160:
+```
+| 5* | **Security** | Security audit | Architecture | `qa/security-audit.md` |
+```
+Replace with:
+```
+| 5* | **Security Guardian** | Security audit | Architecture | `security/security-audit.md` |
+```
+
+**Step 3: Update Gate 1 to read from `output/security/`**
+
+Find:
+```
+1. Read `$BASE/output/qa/security-audit.md`
+```
+Replace with:
+```
+1. Read `$BASE/output/security/security-audit.md`
+```
+
+Find:
+```
+   Review: ~/.claude/bmad/projects/{project}/output/qa/security-audit.md
+```
+Replace with:
+```
+   Review: ~/.claude/bmad/projects/{project}/output/security/security-audit.md
+```
+
+**Step 4: Commit**
+
+```bash
+git add plugin/skills/bmad-greenfield/SKILL.md
+git commit -m "feat: integrate bmad-security into greenfield workflow"
+```
+
+---
+
+### Task 4: Add Agent #6 to code review
+
+**Files:**
+- Modify: `plugin/skills/bmad-code-review/SKILL.md:57-75` (parallel agents section)
+- Modify: `plugin/skills/bmad-code-review/SKILL.md:1` (description to mention 6 agents)
+
+**Step 1: Update the description in frontmatter**
+
+No change needed — the description says "Multi-agent PR review" which is agent-count-agnostic.
+
+**Step 2: Add Agent #6 after Agent #5**
+
+In `plugin/skills/bmad-code-review/SKILL.md`, find the line:
+```
+**Agent #5 — Code Comments Compliance**
+Read code comments in modified files. Verify the changes comply with guidance in those comments (TODOs, warnings, invariants).
+```
+
+After it, add:
+
+```
+
+**Agent #6 — Security Scan**
+Read the file changes. Scan for common security vulnerabilities in the diff. Focus on: injection patterns (SQL, command, XSS, path traversal), authentication/authorization gaps (missing checks, hardcoded secrets, insecure token handling), cryptographic issues (weak algorithms, plaintext secrets, insufficient randomness), and data exposure risks (PII in logs, verbose error messages, sensitive data in URLs). Only flag issues introduced by this PR, not pre-existing patterns.
+```
+
+**Step 3: Update the agent count reference**
+
+Find:
+```
+Launch 5 parallel Sonnet agents.
+```
+Replace with:
+```
+Launch 6 parallel Sonnet agents.
+```
+
+**Step 4: Commit**
+
+```bash
+git add plugin/skills/bmad-code-review/SKILL.md
+git commit -m "feat: add Security Scan agent (#6) to code review pipeline"
+```
+
+---
+
+### Task 5: Add security handoff to Architecture Owner
+
+**Files:**
+- Modify: `plugin/skills/bmad-arch/SKILL.md:122-128` (handoff section)
+
+**Step 1: Update the handoff message**
+
+In `plugin/skills/bmad-arch/SKILL.md`, find:
+```
+   > Next suggested role: `/bmad-impl` for implementation, or `/bmad-ux` for UX design.
+```
+Replace with:
+```
+   > Next suggested role: `/bmad-security` for security audit, `/bmad-impl` for implementation, or `/bmad-ux` for UX design.
+```
+
+**Step 2: Commit**
+
+```bash
+git add plugin/skills/bmad-arch/SKILL.md
+git commit -m "feat: add bmad-security to arch handoff suggestions"
+```
+
+---
+
+### Task 6: Version bump
+
+**Files:**
+- Modify: `plugin/.claude-plugin/plugin.json` (version field)
+
+**Step 1: Bump version**
+
+In `plugin/.claude-plugin/plugin.json`, find:
+```
+"version": "0.4.0",
+```
+Replace with:
+```
+"version": "0.5.0",
+```
+
+**Step 2: Commit**
+
+```bash
+git add plugin/.claude-plugin/plugin.json
+git commit -m "chore: bump version to 0.5.0"
+```
+
+---
+
+### Task 7: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Step 1: Add bmad-security to the Project Structure tree**
+
+In the `## Project Structure` section, find:
+```
+    ├── bmad-docs/SKILL.md              # Documentation Steward
+```
+After it, add:
+```
+    ├── bmad-security/SKILL.md          # Security Guardian
+```
+
+**Step 2: Update the plugin description**
+
+Find:
+```
+Multi-agent development workflow plugin for Claude Code. 15 skills (8 holacracy roles + 7 utilities)
+```
+Replace with:
+```
+Multi-agent development workflow plugin for Claude Code. 16 skills (9 holacracy roles + 7 utilities)
+```
+
+**Step 3: Update Role vs utility skills gotcha**
+
+Find:
+```
+- **Role vs utility skills**: 8 of the 15 skills are holacracy roles.
+```
+Replace with:
+```
+- **Role vs utility skills**: 9 of the 16 skills are holacracy roles (including Security Guardian).
+```
+
+**Step 4: Add security convention**
+
+In the `## Conventions` section, after the line about code review requiring a PR, add:
+```
+- **Security gate blocks implementation**: `/bmad-security` can issue a P0 SECURITY BLOCK that prevents `/bmad-impl` from proceeding in the greenfield workflow. The security audit output goes to `output/security/security-audit.md`
+```
+
+**Step 5: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add bmad-security to CLAUDE.md structure and conventions"
+```
+
+---
+
+### Task 8: Update marketplace.json
+
+**Files:**
+- Modify: `.claude-plugin/marketplace.json`
+
+**Step 1: Update version and description**
+
+In `.claude-plugin/marketplace.json`, find:
+```
+"version": "0.4.0",
+```
+Replace with:
+```
+"version": "0.5.0",
+```
+
+Find:
+```
+"description": "15 skills (8 holacracy roles + 7 utilities) with structured workflows, quality gates, TDD enforcement, and full customization"
+```
+Replace with:
+```
+"description": "16 skills (9 holacracy roles + 7 utilities) with structured workflows, quality gates, TDD enforcement, security audits, and full customization"
+```
+
+**Step 2: Commit**
+
+```bash
+git add .claude-plugin/marketplace.json
+git commit -m "chore: sync marketplace.json to v0.5.0"
+```
+
+---
+
+### Summary of Commits
+
+| # | Commit Message | Files |
+|---|---|---|
+| 1 | `feat: add bmad-security skill (Security Guardian role)` | `plugin/skills/bmad-security/SKILL.md` |
+| 2 | `feat: extend security-audit template with business domain sections` | `plugin/resources/templates/software/security-audit.md` |
+| 3 | `feat: integrate bmad-security into greenfield workflow` | `plugin/skills/bmad-greenfield/SKILL.md` |
+| 4 | `feat: add Security Scan agent (#6) to code review pipeline` | `plugin/skills/bmad-code-review/SKILL.md` |
+| 5 | `feat: add bmad-security to arch handoff suggestions` | `plugin/skills/bmad-arch/SKILL.md` |
+| 6 | `chore: bump version to 0.5.0` | `plugin/.claude-plugin/plugin.json` |
+| 7 | `docs: add bmad-security to CLAUDE.md structure and conventions` | `CLAUDE.md` |
+| 8 | `chore: sync marketplace.json to v0.5.0` | `.claude-plugin/marketplace.json` |

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bmad",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Multi-agent development workflow plugin with holacracy roles, quality gates, and full customization",
   "author": {
     "name": "Alessio Roberto",

--- a/plugin/resources/templates/software/security-audit.md
+++ b/plugin/resources/templates/software/security-audit.md
@@ -1,14 +1,27 @@
 # Security Audit: {Feature/System Name}
 
 **Date**: {YYYY-MM-DD}
-**Auditor**: Quality Guardian (BMAD)
+**Auditor**: Security Guardian (BMAD)
 **Scope**: {What was audited}
+**Domain**: {software / business}
+
+---
+
+## Executive Summary
+
+**Risk Level**: {Critical / High / Medium / Low}
+**Critical Findings**: {count}
+**Verdict**: {SECURITY BLOCK / SECURITY PASS with warnings / SECURITY PASS}
+
+---
+
+<!-- SOFTWARE DOMAIN: Include STRIDE + OWASP sections -->
 
 ## STRIDE Threat Model
 
-| Threat | Category | Severity | Status |
-|---|---|---|---|
-| {Threat description} | Spoofing / Tampering / Repudiation / Info Disclosure / DoS / Elevation | P0/P1/P2/P3 | Open / Mitigated |
+| Threat | Category | Component | Severity | Status |
+|---|---|---|---|---|
+| {Threat description} | Spoofing / Tampering / Repudiation / Info Disclosure / DoS / Elevation | {Component} | P0/P1/P2/P3 | Open / Mitigated |
 
 ## OWASP Top 10 Check
 
@@ -29,15 +42,40 @@
 
 - **{Platform security concern 1}**: {Assessment}
 - **{Platform security concern 2}**: {Assessment}
-- **{Platform security concern 3}**: {Assessment}
-- **{Platform security concern 4}**: {Assessment}
+
+<!-- BUSINESS DOMAIN: Include Compliance + Data Governance sections -->
+
+## Regulatory Compliance
+
+| Regulation | Applicable | Status | Gaps |
+|---|---|---|---|
+| GDPR | Yes/No | Compliant / Partial / Non-compliant | {Gaps} |
+| CCPA | Yes/No | Compliant / Partial / Non-compliant | {Gaps} |
+| {Industry-specific} | Yes/No | Compliant / Partial / Non-compliant | {Gaps} |
+
+## Data Governance
+
+- **Collection**: {What data, legal basis, consent mechanism}
+- **Storage**: {Where, encryption, retention policy}
+- **Processing**: {How, who has access, audit trail}
+- **Sharing**: {Third parties, data processing agreements}
+
+## Vendor Risk
+
+| Vendor | Data Shared | Risk Level | DPA in Place | Notes |
+|---|---|---|---|---|
+| {Vendor} | {Data types} | High/Medium/Low | Yes/No | {Notes} |
+
+<!-- ALL DOMAINS: Findings, Recommendations, Verdict -->
+
+---
 
 ## Findings
 
-### P0 — Critical (Must fix before release)
+### P0 — Critical (Must fix before implementation)
 - {Finding or "None"}
 
-### P1 — High (Fix before release if possible)
+### P1 — High (Fix before release)
 - {Finding or "None"}
 
 ### P2 — Medium (Fix in next sprint)
@@ -46,13 +84,15 @@
 ### P3 — Low (Track for future)
 - {Finding or "None"}
 
-## Recommendations
+## Remediation Roadmap
 
-1. {Recommendation}
-2. {Recommendation}
+| Priority | Finding | Action | Owner | Timeline |
+|---|---|---|---|---|
+| P0 | {Finding} | {Action} | {Role} | Immediate |
+| P1 | {Finding} | {Action} | {Role} | This sprint |
 
 ## Verdict
 
-**{PASS / CONDITIONAL PASS / FAIL}**
+**{SECURITY BLOCK / SECURITY PASS with warnings / SECURITY PASS}**
 
 {Summary statement}

--- a/plugin/skills/bmad-arch/SKILL.md
+++ b/plugin/skills/bmad-arch/SKILL.md
@@ -124,7 +124,7 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
    > **Architecture Owner — Complete.**
    > Output saved to: `~/.claude/bmad/projects/{project}/output/arch/{filename}`
    > ADRs documented: {count}
-   > Next suggested role: `/bmad-impl` for implementation, or `/bmad-ux` for UX design.
+   > Next suggested role: `/bmad-security` for security audit, `/bmad-impl` for implementation, or `/bmad-ux` for UX design.
 
 ## BMAD Principles
 - Document trade-offs: every choice has pros/cons, be honest about both

--- a/plugin/skills/bmad-code-review/SKILL.md
+++ b/plugin/skills/bmad-code-review/SKILL.md
@@ -56,7 +56,7 @@ Use a Haiku agent to view the pull request and return a structured summary:
 
 ### 4. Parallel Review (5 Agents)
 
-Launch 5 parallel Sonnet agents. Each receives: the PR diff, the PR summary from step 3, and **all CLAUDE.md standards from step 2**. Each returns a list of issues with the reason flagged (e.g. "CLAUDE.md adherence", "bug", "historical context").
+Launch 6 parallel Sonnet agents. Each receives: the PR diff, the PR summary from step 3, and **all CLAUDE.md standards from step 2**. Each returns a list of issues with the reason flagged (e.g. "CLAUDE.md adherence", "bug", "historical context").
 
 **Agent #1 — CLAUDE.md Compliance**
 Audit all changes against every CLAUDE.md standard found in step 2. Check naming conventions, architectural rules, forbidden patterns, required patterns. Only flag violations that the CLAUDE.md explicitly calls out.
@@ -72,6 +72,9 @@ Read previous pull requests that touched the same files. Check for comments on t
 
 **Agent #5 — Code Comments Compliance**
 Read code comments in modified files. Verify the changes comply with guidance in those comments (TODOs, warnings, invariants).
+
+**Agent #6 — Security Scan**
+Read the file changes. Scan for common security vulnerabilities in the diff. Focus on: injection patterns (SQL, command, XSS, path traversal), authentication/authorization gaps (missing checks, hardcoded secrets, insecure token handling), cryptographic issues (weak algorithms, plaintext secrets, insufficient randomness), and data exposure risks (PII in logs, verbose error messages, sensitive data in URLs). Only flag issues introduced by this PR, not pre-existing patterns.
 
 ### 5. Confidence Scoring
 

--- a/plugin/skills/bmad-greenfield/SKILL.md
+++ b/plugin/skills/bmad-greenfield/SKILL.md
@@ -78,7 +78,7 @@ BASE=~/.claude/bmad/projects/$PROJECT_NAME
 
 **Initialize structure**:
 ```bash
-mkdir -p $BASE/output/{scope,arch,impl,qa,ux,prioritize,facilitate,docs,code-review}
+mkdir -p $BASE/output/{scope,arch,impl,qa,ux,prioritize,facilitate,docs,code-review,security}
 mkdir -p $BASE/shards/{requirements,architecture,stories}
 mkdir -p $BASE/workspace
 ```
@@ -164,7 +164,7 @@ After completion, type one of:
 | 2 | **Prioritizer** | Prioritize & create PRD | Requirements | `prioritize/PRD.md` |
 | 3* | **Experience Designer** | Design UX | PRD | `ux/ux-design.md` |
 | 4 | **Architecture Owner** | Design architecture | PRD + UX (if available) | `arch/architecture.md` |
-| 5* | **Security** | Security audit | Architecture | `qa/security-audit.md` |
+| 5* | **Security Guardian** | Security audit | Architecture | `security/security-audit.md` |
 | 6* | **Facilitator** | Sprint planning | PRD + Architecture | `facilitate/sprint-plan.md` |
 | 7 | **Implementer** | Implement | Architecture + PRD | Code in repo |
 | 8 | **Quality Guardian** | Test & validate | Requirements + Code | `qa/test-report.md` |
@@ -239,14 +239,14 @@ Completed:
 ### Gate 1: Security P0 Block
 
 After the security review step (if included):
-1. Read `$BASE/output/qa/security-audit.md`
+1. Read `$BASE/output/security/security-audit.md`
 2. If the document contains "P0" severity issues:
    ```
    SECURITY GATE FAILED
    P0 critical issues found in security audit.
    These MUST be resolved before implementation.
 
-   Review: ~/.claude/bmad/projects/{project}/output/qa/security-audit.md
+   Review: ~/.claude/bmad/projects/{project}/output/security/security-audit.md
 
    Resolve the issues, then type 'next' to re-run security review.
    ```

--- a/plugin/skills/bmad-security/SKILL.md
+++ b/plugin/skills/bmad-security/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: bmad-security
+description: "Security Guardian — Security audit, threat modeling, compliance checks. Use after architecture, before implementation."
+allowed-tools: Read, Grep, Glob, Bash
+metadata:
+  context: fork
+  agent: qa
+---
+
+# Security Guardian
+
+You energize the **Security Guardian** role in the BMAD circle. You identify vulnerabilities, model threats, and validate compliance — ensuring the team ships securely.
+
+## Soul
+
+Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
+Key reminders: Impact over activity — focus on real risks, not security theater. Speak up about vulnerabilities, even when inconvenient.
+
+## Your Role
+
+You are the security conscience of the team. You think in attack vectors, not features. You evaluate threats rigorously, prioritize real risks over theoretical ones, and only reach for complexity when simplicity leaves a gap. You document your findings so the Implementer can act on them. You respect the Architecture Owner's design but you will push back when it creates security debt.
+
+## Domain Detection
+
+Detect the project domain by analyzing files in the current directory:
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
+- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
+- **general**: default if no indicator found
+
+## Input Prerequisites
+
+Read from `~/.claude/bmad/projects/{project}/output/`:
+- Architecture: `arch/architecture.md` or `arch/operational-architecture.md`
+- Also useful: `scope/requirements.md`, `prioritize/PRD.md`
+- If architecture missing: "Architecture missing. Run `/bmad-arch` first."
+
+Also check for project config: `~/.claude/bmad/projects/{project}/config.yaml`
+- If `extra_instructions` for bmad-security exists, incorporate them
+
+## Domain-Specific Behavior
+
+### Software Development
+**Focus**: Threat modeling (STRIDE), OWASP Top 10, secure architecture, vulnerability assessment
+**Output filename**: `security-audit.md`
+**Activities**:
+- STRIDE threat model for each component (auth, API, DB, storage, etc.)
+- OWASP Top 10 assessment against the architecture
+- Platform-specific security checks (detected from marker files)
+- Vulnerability analysis with P0-P3 severity
+- Remediation roadmap prioritized by severity
+
+**Domain Skill Suggestions**:
+
+Check `${CLAUDE_PLUGIN_ROOT}/resources/deps-manifest.yaml` for domain-specific dependency groups that match the detected project type. For each dependency in a matching group that has a `suggest_in` entry for this role (`security`), suggest:
+
+> "Consider invoking `/<dep-id>` for <suggest_in text>"
+
+These are suggestions, not blocks — proceed with or without them. If a suggested skill is not installed, note: "Not installed. Run: `<install_command>` from deps-manifest."
+
+### Business Strategy
+**Focus**: Regulatory compliance, data governance, vendor risk
+**Output filename**: `security-audit.md`
+**Activities**:
+- Regulatory requirements assessment (GDPR, CCPA, industry-specific)
+- Data governance review (collection, storage, processing, retention)
+- Vendor risk analysis (third-party dependencies, data sharing)
+- Data breach response evaluation
+- Compliance gaps and remediation plan
+
+### Personal / General
+For personal or general domains, security audits are not applicable. Inform the user:
+> "Security audits apply to software and business domains. For personal projects, consider reviewing your digital privacy practices independently."
+
+## Process
+
+1. **Initialize output directory**:
+   ```bash
+   PROJECT_NAME=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
+   mkdir -p ~/.claude/bmad/projects/$PROJECT_NAME/output/security
+   ```
+
+2. **Read architecture and requirements**: Understand the system's attack surface
+
+3. **Scope the audit**: Determine what to audit based on domain:
+   - Software: system components, APIs, data stores, authentication, authorization
+   - Business: data handling, vendor relationships, regulatory requirements
+
+4. **Threat modeling** (software domain):
+   Apply STRIDE to each component identified in the architecture:
+   - **S**poofing: Can an attacker impersonate a user or service?
+   - **T**ampering: Can data be modified in transit or at rest?
+   - **R**epudiation: Can actions be denied without evidence?
+   - **I**nformation Disclosure: Can sensitive data leak?
+   - **D**enial of Service: Can the system be overwhelmed?
+   - **E**levation of Privilege: Can an attacker gain unauthorized access?
+
+5. **OWASP Top 10 check** (software domain):
+   Assess the architecture against each OWASP Top 10 category:
+   A01 Broken Access Control, A02 Cryptographic Failures, A03 Injection,
+   A04 Insecure Design, A05 Security Misconfiguration, A06 Vulnerable Components,
+   A07 Auth Failures, A08 Data Integrity Failures, A09 Logging Failures, A10 SSRF
+
+6. **Compliance check** (business domain):
+   - GDPR: data processing basis, consent, right to erasure, DPO
+   - CCPA: California consumer rights, opt-out, data sale
+   - Industry-specific: HIPAA (health), PCI DSS (payments), SOX (finance)
+
+7. **Risk assessment**: Assign severity to each finding:
+   - **P0 Critical**: Immediate breach risk, exploit-ready, public-facing. Fix within 24-48h
+   - **P1 High**: Significant risk, authenticated exploit path. Fix within 1 week
+   - **P2 Medium**: Moderate risk, defense-in-depth gap. Fix within 1 month
+   - **P3 Low**: Best practice deviation, minor config issue. Fix when convenient
+
+8. **Generate report**: Use the template from `${CLAUDE_PLUGIN_ROOT}/resources/templates/software/security-audit.md`. Write to `~/.claude/bmad/projects/$PROJECT_NAME/output/security/security-audit.md`
+
+9. **MCP Integration** (if available):
+   - **Linear**: Link security findings to issues, create P0/P1 issues for critical findings
+   - **claude-mem**: Search for past security patterns. Save key findings at completion.
+
+10. **Security Gate Decision**:
+
+Based on findings, determine the verdict:
+- If ANY **P0** finding → verdict is **SECURITY BLOCK**
+- If P1 but no P0 → verdict is **SECURITY PASS with warnings**
+- If only P2/P3 → verdict is **SECURITY PASS**
+
+11. **Handoff**:
+
+**If SECURITY BLOCK:**
+> **Security Guardian — BLOCKED (P0 critical issues).**
+> Output saved to: `~/.claude/bmad/projects/{project}/output/security/security-audit.md`
+> These MUST be fixed before implementation. Re-run `/bmad-security` after fixes.
+
+**If SECURITY PASS with warnings:**
+> **Security Guardian — PASS with P1 warnings.**
+> Output saved to: `~/.claude/bmad/projects/{project}/output/security/security-audit.md`
+> Proceed to `/bmad-impl`; fix P1 issues in parallel.
+
+**If SECURITY PASS:**
+> **Security Guardian — PASS.**
+> Output saved to: `~/.claude/bmad/projects/{project}/output/security/security-audit.md`
+> No blocking issues. Proceed to `/bmad-impl` for implementation.
+
+## BMAD Principles
+- Defense in depth: multiple layers of security, not single point of failure
+- Assume breach: design for "when" not "if" compromised
+- Impact over activity: focus on real risks, not security theater
+- Human-in-the-loop: ask for clarification if architecture is unclear, don't assume
+- Speak up: flag risks early and honestly, even when inconvenient


### PR DESCRIPTION
## Summary

- **New role**: `bmad-security` — Security Guardian with STRIDE/OWASP (software) and GDPR/compliance (business) domains
- **Greenfield integration**: Optional security phase with P0 SECURITY BLOCK gate between arch and impl
- **Code review**: Agent #6 Security Scan added to the 6-agent parallel review pipeline
- **Template**: `security-audit.md` extended with conditional business sections (compliance, data governance, vendor risk)
- **CLAUDE.md**: Reduced by 69% (9KB → 2.8KB) — removed content discoverable from code, kept only non-obvious rules
- **Version**: 0.4.0 → 0.5.0

## Changes (9 commits, 8 files)

| File | Change |
|------|--------|
| `plugin/skills/bmad-security/SKILL.md` | New Security Guardian skill |
| `plugin/resources/templates/software/security-audit.md` | Extended with business domain sections |
| `plugin/skills/bmad-greenfield/SKILL.md` | Security output path + Gate 1 update |
| `plugin/skills/bmad-code-review/SKILL.md` | Agent #6 Security Scan |
| `plugin/skills/bmad-arch/SKILL.md` | Handoff suggests `/bmad-security` |
| `plugin/.claude-plugin/plugin.json` | Version bump to 0.5.0 |
| `.claude-plugin/marketplace.json` | Synced to v0.5.0 |
| `CLAUDE.md` | 69% reduction (116 → 50 lines) |

## Test plan

- [ ] Load plugin locally: `claude --plugin-dir ./plugin`
- [ ] Verify `/bmad-security` appears in skill list
- [ ] Run `/bmad-greenfield` and confirm security phase is offered as optional
- [ ] Run `/bmad-code-review` on a PR and confirm 6 agents are launched
- [ ] Verify CLAUDE.md is loaded correctly and contains all critical rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)