### PR TITLE
refactor: redesign code review for speed and token efficiency

### DIFF
--- a/plugin/skills/bmad-code-review/SKILL.md
+++ b/plugin/skills/bmad-code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bmad-code-review
 description: "Code Review — Multi-agent PR review with CLAUDE.md compliance. Use on any open pull request."
-allowed-tools: Read, Grep, Glob, Task, Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(git rev-parse:*), Bash(git log:*), Bash(git blame:*), Bash(git show:*), Bash(mkdir ~/.claude/bmad/*)
+allowed-tools: Read, Grep, Glob, Task, Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(git rev-parse:*), Bash(git log:*), Bash(git blame:*), Bash(git show:*), Bash(mkdir -p ~/.claude/bmad/*)
 metadata:
   context: same
   agent: general-purpose
@@ -27,80 +27,42 @@ If no argument is provided, ask the user which PR to review.
 
 ## Process
 
-### 1. Eligibility Check
+**Run all steps autonomously — do NOT pause for user input between steps.**
 
-Use a Haiku agent to check if the pull request (a) is closed, (b) is a draft, (c) does not need a code review (e.g. automated PR, trivially obvious), or (d) already has a code review from you. If any apply, stop and explain why.
+### 1. Preflight (you, inline — no agent)
 
-### 2. Gather CLAUDE.md Standards
+Gather context directly (no subagent needed):
+1. Run `gh pr view $ARGUMENTS` — if closed/draft/merged, stop and explain why
+2. Run `gh pr diff $ARGUMENTS` — save the diff for agents
+3. Read the root `CLAUDE.md` (if it exists) — extract all standards, conventions, forbidden patterns
+4. Summarize: what changed, why, risk areas (2-3 sentences max — this is internal context, not output)
 
-This step is **mandatory** — always execute it, never skip.
+### 2. Parallel Review (3 Agents)
 
-Use a Haiku agent to locate all relevant CLAUDE.md files:
-- The root `CLAUDE.md` of the repository (if it exists)
-- Any `CLAUDE.md` files in directories whose files the PR modifies
+Launch **3 parallel Sonnet agents in a single message**. Each receives the diff and CLAUDE.md standards. Each must return issues with: file, line range, description, category, and a self-assessed confidence score (0-100).
 
-Read each file and extract:
-- Coding standards and conventions
-- Required patterns or forbidden patterns
-- Style rules, naming conventions, architectural constraints
-- Any project-specific quality gates or rules
+**Confidence scale** (each agent scores its own findings):
+- **0-25**: Uncertain, might be false positive or pre-existing
+- **50**: Real but minor, nitpick
+- **75**: Very likely real, impacts functionality or violates CLAUDE.md
+- **100**: Certain, double-checked, evidence confirms it
 
-These standards become the **baseline** for the entire review. Every agent in step 4 receives them.
+**Agent A — Standards & Bugs**
+Audit changes against CLAUDE.md rules. Also scan for logic errors, inconsistencies between files, wrong paths, stale references. For CLAUDE.md issues, verify the rule actually exists — if not, cap score at 25.
 
-### 3. Summarize the Change
+**Agent B — History & Context**
+Read git blame and history of modified files. Check previous PRs on same files. Look for: reverted patterns being reintroduced, PR comments that apply here, regressions. Also check code comments (TODOs, warnings, invariants) in modified files for compliance.
 
-Use a Haiku agent to view the pull request and return a structured summary:
-- What changed (files, scope)
-- Why it changed (PR description, linked issues)
-- Risk areas (new dependencies, security-sensitive code, public API changes)
+**Agent C — Security**
+Scan the diff for: injection patterns (SQL, command, XSS, path traversal), auth/authz gaps (missing checks, hardcoded secrets), crypto issues (weak algorithms, plaintext secrets), data exposure (PII in logs, verbose errors, sensitive data in URLs). Only flag issues introduced by this PR.
 
-### 4. Parallel Review (5 Agents)
+### 3. Filter
 
-Launch 6 parallel Sonnet agents. Each receives: the PR diff, the PR summary from step 3, and **all CLAUDE.md standards from step 2**. Each returns a list of issues with the reason flagged (e.g. "CLAUDE.md adherence", "bug", "historical context").
+Collect all issues from the 3 agents. Discard everything with score < 80. If nothing remains, proceed with "no issues found".
 
-**Agent #1 — CLAUDE.md Compliance**
-Audit all changes against every CLAUDE.md standard found in step 2. Check naming conventions, architectural rules, forbidden patterns, required patterns. Only flag violations that the CLAUDE.md explicitly calls out.
+### 4. Post Comment
 
-**Agent #2 — Bug Scan**
-Read the file changes. Shallow scan for obvious bugs. Focus on the diff only, not surrounding code. Target large bugs — logic errors, off-by-one, null safety, race conditions. Ignore nitpicks and things a linter/compiler would catch.
-
-**Agent #3 — Historical Context**
-Read git blame and history of modified code. Identify bugs or regressions in light of that historical context. Check if reverted patterns are being reintroduced.
-
-**Agent #4 — PR Archaeology**
-Read previous pull requests that touched the same files. Check for comments on those PRs that may also apply here.
-
-**Agent #5 — Code Comments Compliance**
-Read code comments in modified files. Verify the changes comply with guidance in those comments (TODOs, warnings, invariants).
-
-**Agent #6 — Security Scan**
-Read the file changes. Scan for common security vulnerabilities in the diff. Focus on: injection patterns (SQL, command, XSS, path traversal), authentication/authorization gaps (missing checks, hardcoded secrets, insecure token handling), cryptographic issues (weak algorithms, plaintext secrets, insufficient randomness), and data exposure risks (PII in logs, verbose error messages, sensitive data in URLs). Only flag issues introduced by this PR, not pre-existing patterns.
-
-### 5. Confidence Scoring
-
-For each issue found in step 4, launch a parallel Haiku agent with the issue, the PR, and all CLAUDE.md files. Score each issue 0–100:
-
-- **0**: False positive. Doesn't hold up to scrutiny, or is pre-existing.
-- **25**: Might be real, but unverified. Stylistic issues not explicitly in CLAUDE.md.
-- **50**: Real but minor. Nitpick or rarely hit in practice.
-- **75**: Very likely real. Verified, important, directly impacts functionality or explicitly mentioned in CLAUDE.md.
-- **100**: Certain. Double-checked, will happen frequently, evidence confirms it.
-
-For CLAUDE.md-flagged issues, the agent must verify the CLAUDE.md **actually** calls out that specific issue. If not, cap score at 25.
-
-### 6. Filter
-
-Discard all issues with score < 80. If no issues remain, proceed to step 8 with "no issues found".
-
-### 7. Re-check Eligibility
-
-Use a Haiku agent to confirm the PR is still open and eligible (hasn't been closed/merged during review).
-
-### 8. Post Comment
-
-Use `gh pr comment` to post the review. Format:
-
----
+Use `gh pr comment` to post the review:
 
 If issues found:
 
@@ -127,7 +89,7 @@ If no issues:
 ```
 ### Code review
 
-No issues found. Checked for bugs and CLAUDE.md compliance.
+No issues found. Checked for bugs, security, and CLAUDE.md compliance.
 
 Generated with [Claude Code](https://claude.ai/code) | BMAD Code Review
 ```
@@ -135,41 +97,33 @@ Generated with [Claude Code](https://claude.ai/code) | BMAD Code Review
 **Link format**: `https://github.com/{owner}/{repo}/blob/{full-sha}/{path}#L{start}-L{end}`
 - Always use the full git SHA (not abbreviated, not a shell command)
 - Provide at least 1 line of context before and after the issue line
-- Repo name must match the repo being reviewed
 
-### 9. Save Review Notes
+### 5. Save & Handoff
 
 ```bash
 PROJECT_NAME=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
 mkdir -p ~/.claude/bmad/projects/$PROJECT_NAME/output/code-review
 ```
 
-Save a summary to `~/.claude/bmad/projects/$PROJECT_NAME/output/code-review/pr-{number}-{date}.md` containing: PR number, issues found, scores, CLAUDE.md rules checked.
+Save summary to `~/.claude/bmad/projects/$PROJECT_NAME/output/code-review/pr-{number}-{date}.md`.
 
-### 10. MCP Integration (if available)
-
-- **Linear**: If the PR is linked to an issue, comment the review summary on the Linear issue
-- **claude-mem**: Save review patterns and recurring issues for future reference
-
-### 11. Handoff
+**MCP Integration** (if available):
+- **Linear**: Comment review summary on linked issues
+- **claude-mem**: Save review patterns for future reference
 
 > **Code Review — Complete.**
 > PR #{number} reviewed. {N} issues found (threshold: 80/100).
-> Output saved to: `~/.claude/bmad/projects/{project}/output/code-review/`
 
 ## False Positive Guide
 
-Do NOT flag these:
-
+Do NOT flag:
 - Pre-existing issues not introduced by this PR
-- Things a linter, typechecker, or compiler would catch (imports, types, formatting)
-- General quality issues (missing tests, poor docs) unless **explicitly required in CLAUDE.md**
-- CLAUDE.md issues silenced in code (e.g. lint-ignore comments)
-- Intentional functionality changes related to the PR's purpose
+- Things a linter/typechecker/compiler would catch
+- General quality issues unless **explicitly required in CLAUDE.md**
+- Intentional changes related to the PR's purpose
 - Issues on lines the author did not modify
 
 ## BMAD Principles
-
 - Impact over activity: only flag issues that genuinely matter
 - Data over opinions: every issue needs evidence, not guesswork
 - Trust the team: assume competence, don't nitpick


### PR DESCRIPTION
## Summary

- Redesign `bmad-code-review` from 11 steps / ~10 agent calls to **5 steps / 3 agent calls**
- Preflight (eligibility + CLAUDE.md + summary) done inline — zero agents
- 3 parallel Sonnet agents replace 5+N: Standards & Bugs, History & Context, Security
- Confidence scoring done inline per agent — no separate Haiku round
- Removed re-check eligibility step
- Added explicit "run autonomously — no user pauses" instruction

## Before vs After

| | Before | After |
|---|---|---|
| Steps | 11 | 5 |
| Agent calls | ~10 | 3 |
| User approvals | ~10 | 3 (single message) |
| Lines | 174 | 130 |

## Test plan

- [ ] Load plugin locally: `claude --plugin-dir ./plugin`
- [ ] Run `/bmad-code-review` on a PR and verify 3 agents launch in parallel
- [ ] Verify no user pauses between steps
- [ ] Verify issues with score < 80 are filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)