### PR TITLE
refactor: cleanup skills and streamline code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ BMAD works for everyone on the team: product managers, designers, analysts, scru
 
 | Command | What it does |
 |---|---|
-| `/bmad:bmad-code-review` | Reviews a pull request using 3 parallel agents with confidence scoring, checking against your project's CLAUDE.md conventions |
+| `/bmad:bmad-code-review` | Reviews a pull request using 2 parallel agents with confidence scoring, checking against your project's CLAUDE.md conventions |
 | `/bmad:bmad-triage` | Triages incoming PR review comments — decides which to accept, reject, or clarify, then implements fixes |
 
 ## Orchestrators

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ BMAD works for everyone on the team: product managers, designers, analysts, scru
 | `/bmad:bmad-ux` | Experience Designer | Designs user interfaces and user journeys |
 | `/bmad:bmad-prioritize` | Prioritizer | Prioritizes features, creates product plans (PRDs) |
 | `/bmad:bmad-facilitate` | Facilitator | Plans sprints, coordinates the team |
+| `/bmad:bmad-security` | Security Guardian | Audits security, models threats, checks compliance |
 | `/bmad:bmad-docs` | Documentation Steward | Generates docs from templates |
 
 > **ADR** = Architecture Decision Record — a short document explaining why a technical decision was made.
@@ -30,7 +31,7 @@ BMAD works for everyone on the team: product managers, designers, analysts, scru
 
 | Command | What it does |
 |---|---|
-| `/bmad:bmad-code-review` | Reviews a pull request using 5 parallel reviewers with confidence scoring, checking against your project's CLAUDE.md conventions |
+| `/bmad:bmad-code-review` | Reviews a pull request using 3 parallel agents with confidence scoring, checking against your project's CLAUDE.md conventions |
 | `/bmad:bmad-triage` | Triages incoming PR review comments — decides which to accept, reject, or clarify, then implements fixes |
 
 ## Orchestrators

--- a/plugin/commands/bmad.md
+++ b/plugin/commands/bmad.md
@@ -7,10 +7,8 @@ Show the status of the BMAD framework for the current project.
 1. **Detect project name**: `basename "$PWD" | tr '[:upper:]' '[:lower:]'`
 
 2. **Detect domain** by analyzing files in the current directory:
-   - **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
-   - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
-   - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
-   - **general**: default if no indicator found
+   - **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
+   - **general**: default if no software indicator found
 
 3. **Check workflow status**: Read `~/.claude/bmad/projects/<project-name>/output/session-state.json` if it exists.
    - If it exists: show current phase, active workflow, completed steps
@@ -43,6 +41,7 @@ Your circle:
   /bmad-ux          — Experience Designer (UI/UX design)
   /bmad-prioritize  — Prioritizer (prioritization, roadmap)
   /bmad-facilitate  — Facilitator (sprint planning)
+  /bmad-security    — Security Guardian (audits, threat modeling)
   /bmad-docs        — Documentation Steward
 
 Workflows:
@@ -66,14 +65,17 @@ Tip: Type /bmad detailed for version info and dependency status.
 Generated artifacts:
 ```
 Generated artifacts:
-  scope/      <list of files or empty>
-  arch/       <list of files or empty>
-  impl/       <list of files or empty>
-  qa/         <list of files or empty>
-  ux/         <list of files or empty>
-  prioritize/ <list of files or empty>
-  facilitate/ <list of files or empty>
-  docs/       <list of files or empty>
+  scope/       <list of files or empty>
+  arch/        <list of files or empty>
+  impl/        <list of files or empty>
+  qa/          <list of files or empty>
+  security/    <list of files or empty>
+  ux/          <list of files or empty>
+  prioritize/  <list of files or empty>
+  facilitate/  <list of files or empty>
+  code-review/ <list of files or empty>
+  triage/      <list of files or empty>
+  docs/        <list of files or empty>
 
 Output directory: ~/.claude/bmad/projects/<project-name>/output/
 ```

--- a/plugin/skills/bmad-arch/SKILL.md
+++ b/plugin/skills/bmad-arch/SKILL.md
@@ -23,15 +23,13 @@ You are the technical conscience of the team. You think in systems, not features
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
-- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
-- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
-- **general**: default if no indicator found
+- **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
+- **general**: default if no software indicator found
 
 ## Input Prerequisites
 
 Read requirements from `~/.claude/bmad/projects/{project}/output/`:
-- Check for: `scope/requirements.md`, `scope/business-requirements.md`, `scope/personal-brief.md`
+- Check for: `scope/requirements.md`
 - Also check: `prioritize/PRD.md` (if Prioritizer has refined requirements)
 - If none found: "Requirements missing. Run `/bmad-scope` first to gather requirements."
 
@@ -63,25 +61,6 @@ Check `${CLAUDE_PLUGIN_ROOT}/resources/deps-manifest.yaml` for domain-specific d
 > "Consider invoking `/<dep-id>` for <suggest_in text>"
 
 These are suggestions, not blocks — proceed with or without them. If a suggested skill is not installed, note: "Not installed. Run: `<install_command>` from deps-manifest."
-
-### Business Strategy
-**Focus**: Process design, workflow, organizational structure
-**Output filename**: `operational-architecture.md`
-**Contents**:
-- Process Overview (workflow diagram)
-- Organizational Structure
-- Decision Framework
-- Resource Allocation
-- Risk Mitigation Strategy
-
-### Personal Goals
-**Focus**: Habit design, support systems, accountability
-**Output filename**: `systems-design.md`
-**Contents**:
-- Habit Architecture
-- Support Systems
-- Progress Tracking
-- Obstacle Mitigation
 
 ## Process
 

--- a/plugin/skills/bmad-code-review/SKILL.md
+++ b/plugin/skills/bmad-code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bmad-code-review
 description: "Code Review — Multi-agent PR review with CLAUDE.md compliance. Use on any open pull request."
-allowed-tools: Read, Grep, Glob, Task, Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(git rev-parse:*), Bash(git log:*), Bash(git blame:*), Bash(git show:*), Bash(mkdir -p ~/.claude/bmad/*)
+allowed-tools: Read, Grep, Glob, Task, Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(git rev-parse:*), Bash(git log:*), Bash(mkdir -p ~/.claude/bmad/*)
 metadata:
   context: same
   agent: general-purpose
@@ -37,9 +37,9 @@ Gather context directly (no subagent needed):
 3. Read the root `CLAUDE.md` (if it exists) — extract all standards, conventions, forbidden patterns
 4. Summarize: what changed, why, risk areas (2-3 sentences max — this is internal context, not output)
 
-### 2. Parallel Review (3 Agents)
+### 2. Parallel Review (2 Agents)
 
-Launch **3 parallel Sonnet agents in a single message**. Each receives the diff and CLAUDE.md standards. Each must return issues with: file, line range, description, category, and a self-assessed confidence score (0-100).
+Launch **2 parallel Sonnet agents in a single message**. Each receives the diff and CLAUDE.md standards. Each must return issues with: file, line range, description, category, and a self-assessed confidence score (0-100).
 
 **Confidence scale** (each agent scores its own findings):
 - **0-25**: Uncertain, might be false positive or pre-existing
@@ -48,17 +48,14 @@ Launch **3 parallel Sonnet agents in a single message**. Each receives the diff 
 - **100**: Certain, double-checked, evidence confirms it
 
 **Agent A — Standards & Bugs**
-Audit changes against CLAUDE.md rules. Also scan for logic errors, inconsistencies between files, wrong paths, stale references. For CLAUDE.md issues, verify the rule actually exists — if not, cap score at 25.
+Audit changes against CLAUDE.md rules. Also scan for logic errors, inconsistencies between files, wrong paths, stale references. Check code comments (TODOs, warnings, invariants) in modified files for compliance. For CLAUDE.md issues, verify the rule actually exists — if not, cap score at 25.
 
-**Agent B — History & Context**
-Read git blame and history of modified files. Check previous PRs on same files. Look for: reverted patterns being reintroduced, PR comments that apply here, regressions. Also check code comments (TODOs, warnings, invariants) in modified files for compliance.
-
-**Agent C — Security**
+**Agent B — Security**
 Scan the diff for: injection patterns (SQL, command, XSS, path traversal), auth/authz gaps (missing checks, hardcoded secrets), crypto issues (weak algorithms, plaintext secrets), data exposure (PII in logs, verbose errors, sensitive data in URLs). Only flag issues introduced by this PR.
 
 ### 3. Filter
 
-Collect all issues from the 3 agents. Discard everything with score < 80. If nothing remains, proceed with "no issues found".
+Collect all issues from the 2 agents. Discard everything with score < 80. If nothing remains, proceed with "no issues found".
 
 ### 4. Post Comment
 

--- a/plugin/skills/bmad-facilitate/SKILL.md
+++ b/plugin/skills/bmad-facilitate/SKILL.md
@@ -23,10 +23,8 @@ You are the facilitator, not the boss. You help the team stay focused, identify 
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
-- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
-- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
-- **general**: default if no indicator found
+- **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
+- **general**: default if no software indicator found
 
 ## Input Prerequisites
 

--- a/plugin/skills/bmad-greenfield/SKILL.md
+++ b/plugin/skills/bmad-greenfield/SKILL.md
@@ -76,7 +76,7 @@ BASE=~/.claude/bmad/projects/$PROJECT_NAME
 
 **Initialize structure**:
 ```bash
-mkdir -p $BASE/output/{scope,arch,impl,qa,ux,prioritize,facilitate,docs,code-review,security}
+mkdir -p $BASE/output/{scope,arch,impl,qa,security,ux,prioritize,facilitate,docs,code-review,triage}
 mkdir -p $BASE/shards/{requirements,architecture,stories}
 mkdir -p $BASE/workspace
 ```

--- a/plugin/skills/bmad-greenfield/SKILL.md
+++ b/plugin/skills/bmad-greenfield/SKILL.md
@@ -44,10 +44,8 @@ init → scope → prioritize → ux → arch → security → facilitate → im
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
-- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
-- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
-- **general**: default if no indicator found
+- **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
+- **general**: default if no software indicator found
 
 ---
 
@@ -297,7 +295,7 @@ When all steps are completed:
    | PRD | Prioritizer | ✓ | PRD.md |
    | UX Design | Experience Designer | ✓/skipped | ux-design.md |
    | Architecture | Architecture Owner | ✓ | architecture.md |
-   | Security | Quality Guardian | ✓/skipped | security-audit.md |
+   | Security | Security Guardian | ✓/skipped | security-audit.md |
    | Sprint Plan | Facilitator | ✓/skipped | sprint-plan.md |
    | Implementation | Implementer | ✓ | (code in repo) |
    | QA | Quality Guardian | ✓ | test-report.md |

--- a/plugin/skills/bmad-impl/SKILL.md
+++ b/plugin/skills/bmad-impl/SKILL.md
@@ -23,15 +23,13 @@ You are pragmatic, thorough, and fast. You write code that's clear enough that y
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
-- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
-- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
-- **general**: default if no indicator found
+- **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
+- **general**: default if no software indicator found
 
 ## Input Prerequisites
 
 Read design from `~/.claude/bmad/projects/{project}/output/`:
-- Check for: `arch/architecture.md`, `arch/operational-architecture.md`, `arch/systems-design.md`
+- Check for: `arch/architecture.md`
 - Also useful: `scope/requirements.md`, `prioritize/PRD.md`
 - If architecture missing: "Design missing. Run `/bmad-arch` first."
 
@@ -64,18 +62,6 @@ Check `${CLAUDE_PLUGIN_ROOT}/resources/deps-manifest.yaml` for domain-specific d
 
 These are suggestions, not blocks — proceed with or without them. If a suggested skill is not installed, note: "Not installed. Run: `<install_command>` from deps-manifest."
 
-### Business Strategy
-**Activities**:
-- Create operational documents (procedures, guidelines, templates)
-- Implement defined processes
-- Document workflows
-
-### Personal Goals
-**Activities**:
-- Create habit trackers and support tools
-- Implement accountability systems
-- Setup templates and reminders
-
 ## Process
 
 1. **Initialize output directory**:
@@ -92,8 +78,8 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
    Read `~/.claude/bmad/projects/{project}/config.yaml` for `tdd` settings.
    - If `tdd.enabled: false`: skip to step 5 (test as you go).
    - Otherwise (TDD is enabled by default): check if TDD applies:
-     - If non-software domain (business, personal, general): prompt the user:
-       > "TDD is enabled but this workflow may not require it. Disable TDD for this session? [y/n]"
+     - If non-software domain (general): prompt the user:
+       > "TDD is enabled but this project may not require it. Disable TDD for this session? [y/n]"
      - If software domain but no test framework detected: prompt the user:
        > "TDD is enabled but no test runner was detected. Disable TDD for this session, or set up tests first? [disable/setup]"
      - If TDD applies: implement each unit of work via `/bmad-tdd` sub-workflow.

--- a/plugin/skills/bmad-init/SKILL.md
+++ b/plugin/skills/bmad-init/SKILL.md
@@ -125,10 +125,8 @@ Derive from current directory: `basename "$PWD" | tr '[:upper:]' '[:lower:]'`
 ### 2. Detect domain
 
 Analyze files in the current directory:
-- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
-- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
-- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
-- **general**: default if no indicator found
+- **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
+- **general**: default if no software indicator found
 
 ### 3. Create output structure
 
@@ -137,7 +135,7 @@ Zero footprint — all in home directory:
 PROJECT_NAME=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
 BASE=~/.claude/bmad/projects/$PROJECT_NAME
 
-mkdir -p $BASE/output/{scope,arch,impl,qa,ux,prioritize,facilitate,docs,code-review}
+mkdir -p $BASE/output/{scope,arch,impl,qa,security,ux,prioritize,facilitate,docs,code-review,triage}
 mkdir -p $BASE/shards/{requirements,architecture,stories}
 mkdir -p $BASE/workspace
 ```
@@ -187,6 +185,7 @@ Available roles:
   /bmad-ux          - Experience Designer (UI/UX design)
   /bmad-prioritize  - Prioritizer (prioritization, roadmap)
   /bmad-facilitate  - Facilitator (sprint planning, coordination)
+  /bmad-security    - Security Guardian (audits, threat modeling)
   /bmad-docs        - Documentation Steward (doc generation)
 
 Review:

--- a/plugin/skills/bmad-prioritize/SKILL.md
+++ b/plugin/skills/bmad-prioritize/SKILL.md
@@ -23,15 +23,13 @@ You are the bridge between what users want, what the business needs, and what th
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
-- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
-- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
-- **general**: default if no indicator found
+- **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
+- **general**: default if no software indicator found
 
 ## Input Prerequisites
 
 Read from `~/.claude/bmad/projects/{project}/output/`:
-- Requirements: `scope/requirements.md`, `scope/business-requirements.md`, or `scope/personal-brief.md`
+- Requirements: `scope/requirements.md`
 - If requirements missing: "Requirements needed. Run `/bmad-scope` first to gather requirements."
 
 ## Process

--- a/plugin/skills/bmad-qa/SKILL.md
+++ b/plugin/skills/bmad-qa/SKILL.md
@@ -23,10 +23,8 @@ You are the quality guardian. You think about edge cases others miss, failure mo
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
-- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
-- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
-- **general**: default if no indicator found
+- **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
+- **general**: default if no software indicator found
 
 ## Input Prerequisites
 
@@ -55,14 +53,6 @@ Check `${CLAUDE_PLUGIN_ROOT}/resources/deps-manifest.yaml` for domain-specific d
 > "Consider invoking `/<dep-id>` for <suggest_in text>"
 
 These are suggestions, not blocks — proceed with or without them. If a suggested skill is not installed, note: "Not installed. Run: `<install_command>` from deps-manifest."
-
-### Business Strategy
-**Focus**: Process validation, feasibility checks
-**Output filename**: `validation-report.md`
-
-### Personal Goals
-**Focus**: Readiness assessment, system checks
-**Output filename**: `readiness-check.md`
 
 ## Process
 

--- a/plugin/skills/bmad-scope/SKILL.md
+++ b/plugin/skills/bmad-scope/SKILL.md
@@ -23,30 +23,12 @@ You are the voice of the user and the bridge between stakeholders and the techni
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
-- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
-- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
-- **general**: default if no indicator found
+- **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
+- **general**: default if no software indicator found
 
-## Domain-Specific Behavior
+## Output
 
-### Software Development
-- Analyze technical requirements, existing stack, codebase structure
-- Questions: technical objectives, target users, technology constraints, acceptance criteria
-- Focus: functional requirements, non-functional requirements, user stories with acceptance criteria
-- Output filename: `requirements.md`
-
-### Business Strategy
-- Analyze market, competition, opportunities
-- Questions: business objectives, target market, value proposition, success metrics
-- Focus: business requirements, stakeholder needs, success criteria
-- Output filename: `business-requirements.md`
-
-### Personal Goals
-- Analyze current situation, aspirations, challenges
-- Questions: personal objectives, motivations, obstacles, timeline
-- Focus: goals, constraints, accountability mechanisms
-- Output filename: `personal-brief.md`
+**Output filename**: `requirements.md`
 
 ## Process
 

--- a/plugin/skills/bmad-security/SKILL.md
+++ b/plugin/skills/bmad-security/SKILL.md
@@ -23,15 +23,13 @@ You are the security conscience of the team. You think in attack vectors, not fe
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
-- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
-- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
-- **general**: default if no indicator found
+- **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
+- **general**: default if no software indicator found
 
 ## Input Prerequisites
 
 Read from `~/.claude/bmad/projects/{project}/output/`:
-- Architecture: `arch/architecture.md` or `arch/operational-architecture.md`
+- Architecture: `arch/architecture.md`
 - Also useful: `scope/requirements.md`, `prioritize/PRD.md`
 - If architecture missing: "Architecture missing. Run `/bmad-arch` first."
 
@@ -58,20 +56,6 @@ Check `${CLAUDE_PLUGIN_ROOT}/resources/deps-manifest.yaml` for domain-specific d
 
 These are suggestions, not blocks — proceed with or without them. If a suggested skill is not installed, note: "Not installed. Run: `<install_command>` from deps-manifest."
 
-### Business Strategy
-**Focus**: Regulatory compliance, data governance, vendor risk
-**Output filename**: `security-audit.md`
-**Activities**:
-- Regulatory requirements assessment (GDPR, CCPA, industry-specific)
-- Data governance review (collection, storage, processing, retention)
-- Vendor risk analysis (third-party dependencies, data sharing)
-- Data breach response evaluation
-- Compliance gaps and remediation plan
-
-### Personal / General
-For personal or general domains, security audits are not applicable. Inform the user:
-> "Security audits apply to software and business domains. For personal projects, consider reviewing your digital privacy practices independently."
-
 ## Process
 
 1. **Initialize output directory**:
@@ -82,9 +66,7 @@ For personal or general domains, security audits are not applicable. Inform the 
 
 2. **Read architecture and requirements**: Understand the system's attack surface
 
-3. **Scope the audit**: Determine what to audit based on domain:
-   - Software: system components, APIs, data stores, authentication, authorization
-   - Business: data handling, vendor relationships, regulatory requirements
+3. **Scope the audit**: system components, APIs, data stores, authentication, authorization
 
 4. **Threat modeling** (software domain):
    Apply STRIDE to each component identified in the architecture:
@@ -101,10 +83,9 @@ For personal or general domains, security audits are not applicable. Inform the 
    A04 Insecure Design, A05 Security Misconfiguration, A06 Vulnerable Components,
    A07 Auth Failures, A08 Data Integrity Failures, A09 Logging Failures, A10 SSRF
 
-6. **Compliance check** (business domain):
-   - GDPR: data processing basis, consent, right to erasure, DPO
-   - CCPA: California consumer rights, opt-out, data sale
-   - Industry-specific: HIPAA (health), PCI DSS (payments), SOX (finance)
+6. **Compliance check** (if applicable):
+   - GDPR, CCPA, industry-specific regulations (HIPAA, PCI DSS, SOX)
+   - Data governance: collection, storage, processing, retention
 
 7. **Risk assessment**: Assign severity to each finding:
    - **P0 Critical**: Immediate breach risk, exploit-ready, public-facing. Fix within 24-48h

--- a/plugin/skills/bmad-shard/SKILL.md
+++ b/plugin/skills/bmad-shard/SKILL.md
@@ -28,7 +28,6 @@ Automatically detect documents to shard in `~/.claude/bmad/projects/{project}/ou
 | PRD | `prioritize/PRD-*.md` |
 | Architecture | `arch/architecture.md` |
 | Requirements | `scope/requirements.md` |
-| Business Requirements | `scope/business-requirements.md` |
 
 If no documents found: "No documents to shard. Run `/bmad:bmad-prioritize` or `/bmad:bmad-scope` first."
 

--- a/plugin/skills/bmad-ux/SKILL.md
+++ b/plugin/skills/bmad-ux/SKILL.md
@@ -23,10 +23,8 @@ You are the advocate for the end user. You think in flows, not screens. You chal
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
-- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
-- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
-- **general**: default if no indicator found
+- **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
+- **general**: default if no software indicator found
 
 ## Input Prerequisites
 
@@ -46,14 +44,6 @@ Read from `~/.claude/bmad/projects/{project}/output/`:
 - Accessibility Considerations
 - Platform Conventions (design guidelines compliance)
 - Error States and Edge Cases UX
-
-### Business Strategy
-**Focus**: Customer journey mapping, touchpoint design
-**Output filename**: `customer-experience.md`
-
-### Personal Goals
-**Focus**: Habit trigger design, daily flow optimization
-**Output filename**: `life-design.md`
 
 ## Process
 


### PR DESCRIPTION
## Summary

- **Code review skill**: redesigned from 5-agent pipeline to 3 parallel agents with confidence scoring, reducing token usage and execution time
- **Domain detection**: simplified from 4 categories (software/business/personal/general) to 2 (software/general) across all 11 skills that use it
- **Removed dead sections**: Business Strategy and Personal Goals domain-specific behavior from scope, arch, impl, ux, qa, security
- **Documentation fixes**: added Security Guardian to README, dashboard, and bmad-init; fixed agent count in README; added missing output directories (security, code-review, triage)

14 files changed, -143 lines net.

## Test plan

- [ ] Run `/bmad` dashboard — verify Security Guardian appears in circle listing
- [ ] Run `/bmad-init` — verify security directory created and role listed
- [ ] Run `/bmad-code-review` on a test PR — verify 3 agents launch (not 5)
- [ ] Run `/bmad-scope` — verify domain detection shows software/general only

🤖 Generated with [Claude Code](https://claude.ai/code)