### PR TITLE
feat: model routing for BMAD agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "bmad",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "source": "./plugin",
       "description": "16 skills (9 holacracy roles + 7 utilities) with structured workflows, quality gates, TDD enforcement, security audits, and full customization"
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ docs/                                  # CUSTOMIZATION.md, GETTING-STARTED.md, M
 
 **TDD**: On by default. `bmad-impl` uses `/bmad-tdd` for red-green-refactor. `bmad-qa` verifies via commit history. Disable: `tdd.enabled: false` in config.yaml. Enforcement: `hard` (blocks) or `soft` (warns).
 
+**Model routing**: Fork-context skills specify a default model (opus/sonnet/haiku) in frontmatter `metadata.model`. Orchestrators pass the `model` parameter to Task tool. Override per-project in `config.yaml` under `agents.<name>.model`. Same-context skills inherit the session model.
+
 **Holacracy**: Roles have purposes, not personas. Reference roles, not names. External comms use team voice.
 
 ## Gotchas

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -143,6 +143,53 @@ To add a new role to the greenfield orchestrator:
 
 ---
 
+## 6. Model Routing
+
+BMAD assigns a default Claude model to each fork-context role based on task complexity. Opus handles deep reasoning (architecture, security, implementation), Sonnet handles structured work (scope, prioritization, QA), and Haiku handles lightweight coordination.
+
+### Default Assignments
+
+| Role | Default Model | Rationale |
+|------|--------------|-----------|
+| Scope Clarifier | sonnet | Structured requirements gathering |
+| Prioritizer | sonnet | Feature prioritization |
+| Experience Designer | sonnet | UX design patterns |
+| Architecture Owner | opus | Deep trade-off reasoning |
+| Security Guardian | opus | Adversarial threat modeling |
+| Facilitator | haiku | Lightweight coordination |
+| Implementer | opus | Code generation quality |
+| Quality Guardian | sonnet | Criteria-based validation |
+| Code Review agents | sonnet | Pattern-matching review |
+
+### Override via config.yaml
+
+```yaml
+agents:
+  bmad-arch:
+    model: opus       # deep reasoning tasks
+  bmad-scope:
+    model: sonnet     # structured tasks
+  bmad-facilitate:
+    model: haiku      # lightweight tasks
+
+# Code review agent models
+code_review:
+  agent_a_model: sonnet
+  agent_b_model: sonnet
+```
+
+### How It Works
+
+- **Fork-context skills** (`context: fork`) specify `model:` in frontmatter metadata. Orchestrators pass this to the Task tool's `model` parameter.
+- **Same-context skills** (`context: same`) inherit the session model and cannot be overridden.
+- **Config overrides** take precedence over frontmatter defaults.
+
+### Cost Implications
+
+Model routing lets you optimize cost without sacrificing quality where it matters. Approximate relative cost per token: Opus (5x), Sonnet (1x), Haiku (0.2x).
+
+---
+
 ## For Developers: Context Model Reference
 
 > This section is for developers who are modifying or creating roles. You can skip this if you're just using BMAD.

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -159,7 +159,8 @@ BMAD assigns a default Claude model to each fork-context role based on task comp
 | Facilitator | haiku | Lightweight coordination |
 | Implementer | opus | Code generation quality |
 | Quality Guardian | sonnet | Criteria-based validation |
-| Code Review agents | sonnet | Pattern-matching review |
+
+Code review agents (spawned by `bmad-code-review` via Task tool) also default to **sonnet**. Configure via `code_review.agent_a_model` and `code_review.agent_b_model` in config.yaml. Note: `bmad-code-review` itself is same-context and inherits the session model — only its spawned agents are configurable.
 
 ### Override via config.yaml
 

--- a/docs/plans/2026-02-24-model-routing.md
+++ b/docs/plans/2026-02-24-model-routing.md
@@ -14,7 +14,7 @@
 
 ### Current State
 
-16 BMAD skills. 7 use `context: fork` (run as subagents), 8 use `context: same` (inline). One skill (bmad-code-review) explicitly spawns 2 parallel Task agents.
+16 BMAD skills. 8 use `context: fork` (run as subagents), 8 use `context: same` (inline). One skill (bmad-code-review) explicitly spawns 2 parallel Task agents.
 
 **Fork-context skills** (subagent, model selectable):
 
@@ -82,8 +82,6 @@ agents:
     model: sonnet
   bmad-prioritize:
     model: sonnet
-  bmad-ux:
-    model: sonnet
   bmad-arch:
     model: opus
     context_files:
@@ -137,7 +135,7 @@ git commit -m "feat: add model routing config to config-example.yaml"
 
 ## Task 2: Add Model Directive to Fork-Context Skills
 
-For each of the 7 fork-context skills, add a `## Model` section that documents the recommended model and instructs the runtime to use it.
+For each of the 8 fork-context skills, add a `## Model` section that documents the recommended model and instructs the runtime to use it.
 
 **Files:**
 - Modify: `plugin/skills/bmad-scope/SKILL.md`
@@ -259,7 +257,7 @@ Add a "Model" column to the existing table (line ~159):
 | 2 | **Prioritizer** | sonnet | Prioritize & create PRD | Requirements | `prioritize/PRD.md` |
 | 3* | **Experience Designer** | sonnet | Design UX | PRD | `ux/ux-design.md` |
 | 4 | **Architecture Owner** | opus | Design architecture | PRD + UX (if available) | `arch/architecture.md` |
-| 5* | **Security Guardian** | opus | Security audit | Architecture | `security/security-audit.md` |
+| 5 | **Security Guardian** | opus | Security audit | Architecture | `security/security-audit.md` |
 | 6* | **Facilitator** | haiku | Sprint planning | PRD + Architecture | `facilitate/sprint-plan.md` |
 | 7 | **Implementer** | opus | Implement | Architecture + PRD | Code in repo |
 | 8 | **Quality Guardian** | sonnet | Test & validate | Requirements + Code | `qa/test-report.md` |
@@ -401,7 +399,7 @@ git commit -m "docs: add model routing section to CUSTOMIZATION.md"
 
 **Step 1: Bump version**
 
-Change version from `"0.5.1"` to `"0.6.0"` (new feature = minor bump).
+Change version from `"0.5.2"` to `"0.6.0"` (new feature = minor bump).
 
 **Step 2: Commit**
 
@@ -425,7 +423,8 @@ After all tasks:
 - [ ] CLAUDE.md has model routing rule
 - [ ] CUSTOMIZATION.md has model routing documentation
 - [ ] plugin.json version is 0.6.0
-- [ ] No same-context skills were modified (they can't change model)
+- [ ] No same-context skills were given `model:` in frontmatter
+- [ ] marketplace.json version synced to 0.6.0
 
 ## Risk Notes
 

--- a/docs/plans/2026-02-24-model-routing.md
+++ b/docs/plans/2026-02-24-model-routing.md
@@ -1,0 +1,434 @@
+# Model Routing for BMAD Agents — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Allow BMAD skills to specify which Claude model (Opus, Sonnet, Haiku) each agent should use, reducing cost on lightweight tasks and reserving Opus for high-reasoning work.
+
+**Architecture:** Explicit model directives in orchestrator skills (bmad-greenfield, bmad-code-review) and in fork-context skills that spawn subagents. Config override via `config.yaml` per-project. No changes to Claude Code internals — uses existing `model` parameter of the Task tool.
+
+**Tech Stack:** Pure Markdown (SKILL.md edits), YAML (config-example.yaml)
+
+---
+
+## Context
+
+### Current State
+
+16 BMAD skills. 7 use `context: fork` (run as subagents), 8 use `context: same` (inline). One skill (bmad-code-review) explicitly spawns 2 parallel Task agents.
+
+**Fork-context skills** (subagent, model selectable):
+
+| Skill | Agent Type | Current Model |
+|-------|-----------|---------------|
+| bmad-scope | Explore | inherited |
+| bmad-prioritize | general-purpose | inherited |
+| bmad-ux | Plan | inherited |
+| bmad-arch | Plan | inherited |
+| bmad-security | qa | inherited |
+| bmad-facilitate | general-purpose | inherited |
+| bmad-impl | general-purpose | inherited |
+| bmad-qa | qa | inherited |
+
+**Same-context skills** (inline, NOT model-selectable):
+
+| Skill | Notes |
+|-------|-------|
+| bmad-greenfield | Orchestrator — guides user, invokes other skills |
+| bmad-code-review | Spawns 2 Task agents (model selectable for those) |
+| bmad-tdd | Interactive, runs in conversation |
+| bmad-docs | Interactive, runs in conversation |
+| bmad-sprint | Interactive, runs in conversation |
+| bmad-shard | Utility, runs in conversation |
+| bmad-triage | Interactive, runs in conversation |
+| bmad-init | Setup, runs in conversation |
+
+### Model Assignment Strategy
+
+| Skill | Recommended Model | Rationale |
+|-------|------------------|-----------|
+| bmad-scope | sonnet | Structured requirements gathering, pattern work |
+| bmad-prioritize | sonnet | Prioritization is structured, not deep reasoning |
+| bmad-ux | sonnet | Design patterns, wireframes — structured output |
+| bmad-arch | opus | Architecture trade-offs require deep reasoning |
+| bmad-security | opus | Threat modeling requires adversarial thinking |
+| bmad-facilitate | haiku | Sprint planning is coordination, lightweight |
+| bmad-impl | opus | Code generation benefits from best reasoning |
+| bmad-qa | sonnet | Validation against defined criteria |
+| code-review Agent A | sonnet | Standards checking (already sonnet) |
+| code-review Agent B | sonnet | Security scan (already sonnet) |
+
+### Key Constraint
+
+Skills with `context: same` inherit the session model. Only fork-context skills and explicitly spawned Task agents can have their model changed. The orchestrators (greenfield, code-review) run inline but **instruct** users to invoke fork-context skills where model selection takes effect.
+
+---
+
+## Task 1: Add Model Routing to config-example.yaml
+
+**Files:**
+- Modify: `plugin/resources/templates/config-example.yaml`
+
+**Step 1: Add model field to agents section**
+
+Add a `model:` field with documentation to the agents config section. After the existing `agents:` block, each agent entry gets a new optional `model` key.
+
+```yaml
+# Model routing — assign Claude model per role (opus, sonnet, haiku)
+# Roles with context: fork run as subagents and respect this setting.
+# Roles with context: same inherit the session model (setting is ignored).
+# Default: inherits from session (usually opus).
+agents:
+  bmad-scope:
+    model: sonnet
+  bmad-prioritize:
+    model: sonnet
+  bmad-ux:
+    model: sonnet
+  bmad-arch:
+    model: opus
+    context_files:
+      - docs/ARCHITECTURE.md
+      - docs/ADR/
+    extra_instructions: |
+      This project uses a layered architecture with dependency injection.
+      All new modules must follow the existing pattern.
+  bmad-security:
+    model: opus
+  bmad-facilitate:
+    model: haiku
+  bmad-impl:
+    model: opus
+    context_files:
+      - src/
+    extra_instructions: |
+      Follow project coding standards and existing conventions.
+      All public APIs must have documentation comments.
+  bmad-qa:
+    model: sonnet
+    extra_instructions: |
+      Minimum test coverage target: 80%.
+      Focus on integration tests for data flows.
+  bmad-ux:
+    model: sonnet
+    extra_instructions: |
+      Follow platform design guidelines.
+      Support accessibility features.
+```
+
+**Step 2: Add code-review model config**
+
+Add a new section for code-review agent model selection:
+
+```yaml
+# Code review agent models (bmad-code-review spawns 2 parallel agents)
+code_review:
+  agent_a_model: sonnet    # Standards & Bugs
+  agent_b_model: sonnet    # Security
+```
+
+**Step 3: Commit**
+
+```bash
+git add plugin/resources/templates/config-example.yaml
+git commit -m "feat: add model routing config to config-example.yaml"
+```
+
+---
+
+## Task 2: Add Model Directive to Fork-Context Skills
+
+For each of the 7 fork-context skills, add a `## Model` section that documents the recommended model and instructs the runtime to use it.
+
+**Files:**
+- Modify: `plugin/skills/bmad-scope/SKILL.md`
+- Modify: `plugin/skills/bmad-prioritize/SKILL.md`
+- Modify: `plugin/skills/bmad-ux/SKILL.md`
+- Modify: `plugin/skills/bmad-arch/SKILL.md`
+- Modify: `plugin/skills/bmad-security/SKILL.md`
+- Modify: `plugin/skills/bmad-facilitate/SKILL.md`
+- Modify: `plugin/skills/bmad-impl/SKILL.md`
+- Modify: `plugin/skills/bmad-qa/SKILL.md`
+
+**Step 1: Add model field to frontmatter metadata**
+
+For each skill, add `model:` to the metadata block. Example for bmad-arch:
+
+```yaml
+metadata:
+  context: fork
+  agent: Plan
+  model: opus
+```
+
+Full mapping:
+
+| Skill | model value |
+|-------|------------|
+| bmad-scope | sonnet |
+| bmad-prioritize | sonnet |
+| bmad-ux | sonnet |
+| bmad-arch | opus |
+| bmad-security | opus |
+| bmad-facilitate | haiku |
+| bmad-impl | opus |
+| bmad-qa | sonnet |
+
+**Step 2: Add Model section to each skill body**
+
+After the `## Soul` section (or `## Your Identity` if present), add:
+
+```markdown
+## Model
+
+**Default model**: {opus|sonnet|haiku}
+**Override**: Set `agents.bmad-{name}.model` in project `config.yaml`.
+**Rationale**: {one sentence why this model}.
+
+> When invoked by an orchestrator (bmad-greenfield), use the Task tool with `model: "{model}"` unless overridden by config.
+```
+
+Example for bmad-arch:
+
+```markdown
+## Model
+
+**Default model**: opus
+**Override**: Set `agents.bmad-arch.model` in project `config.yaml`.
+**Rationale**: Architecture decisions require deep reasoning about trade-offs and system design.
+
+> When invoked by an orchestrator (bmad-greenfield), use the Task tool with `model: "opus"` unless overridden by config.
+```
+
+Example for bmad-facilitate:
+
+```markdown
+## Model
+
+**Default model**: haiku
+**Override**: Set `agents.bmad-facilitate.model` in project `config.yaml`.
+**Rationale**: Sprint coordination is structured and lightweight, does not require deep reasoning.
+
+> When invoked by an orchestrator (bmad-greenfield), use the Task tool with `model: "haiku"` unless overridden by config.
+```
+
+**Step 3: Commit**
+
+```bash
+git add plugin/skills/bmad-*/SKILL.md
+git commit -m "feat: add model routing directives to all fork-context skills"
+```
+
+---
+
+## Task 3: Update bmad-greenfield Orchestrator
+
+**Files:**
+- Modify: `plugin/skills/bmad-greenfield/SKILL.md`
+
+**Step 1: Add Model Routing section**
+
+After the `## Domain Detection` section (line ~48), add:
+
+```markdown
+## Model Routing
+
+Each role runs with a recommended Claude model. The orchestrator passes the `model` parameter when presenting role invocations. Users can override per-project in `config.yaml`.
+
+| Role | Default Model | Rationale |
+|------|--------------|-----------|
+| Scope Clarifier | sonnet | Structured requirements gathering |
+| Prioritizer | sonnet | Feature prioritization |
+| Experience Designer | sonnet | UX design patterns |
+| Architecture Owner | opus | Deep trade-off reasoning |
+| Security Guardian | opus | Adversarial threat modeling |
+| Facilitator | haiku | Lightweight coordination |
+| Implementer | opus | Code generation quality |
+| Quality Guardian | sonnet | Criteria-based validation |
+
+**Config override**: `agents.bmad-{name}.model` in `~/.claude/bmad/projects/{project}/config.yaml`
+```
+
+**Step 2: Update Role Sequence Detail table**
+
+Add a "Model" column to the existing table (line ~159):
+
+```markdown
+| Step | Role | Model | Purpose | Input | Output |
+|---|---|---|---|---|---|
+| 1 | **Scope Clarifier** | sonnet | Gather requirements | User description | `scope/requirements.md` |
+| 2 | **Prioritizer** | sonnet | Prioritize & create PRD | Requirements | `prioritize/PRD.md` |
+| 3* | **Experience Designer** | sonnet | Design UX | PRD | `ux/ux-design.md` |
+| 4 | **Architecture Owner** | opus | Design architecture | PRD + UX (if available) | `arch/architecture.md` |
+| 5* | **Security Guardian** | opus | Security audit | Architecture | `security/security-audit.md` |
+| 6* | **Facilitator** | haiku | Sprint planning | PRD + Architecture | `facilitate/sprint-plan.md` |
+| 7 | **Implementer** | opus | Implement | Architecture + PRD | Code in repo |
+| 8 | **Quality Guardian** | sonnet | Test & validate | Requirements + Code | `qa/test-report.md` |
+```
+
+**Step 3: Update Step Display template**
+
+Add model info to the step display block (line ~138):
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Step {N}/{total}: {Role Name} [{model}]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Purpose: {What this role will do}
+Model: {opus|sonnet|haiku} (override in config.yaml)
+Input: {What artifacts from previous steps are available}
+Output: {What artifact this role will produce}
+
+Please invoke the role:
+→ /bmad:bmad-{name}
+
+After completion, type one of:
+  next  — proceed to next step
+  skip  — skip this step (optional phases only)
+  pause — save progress and exit
+  back  — return to previous step
+  exit  — exit workflow
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**Step 4: Update session-state.json schema**
+
+Add model_routing to the workflow object in the init template (line ~100):
+
+```json
+"model_routing": {
+  "bmad-scope": "sonnet",
+  "bmad-prioritize": "sonnet",
+  "bmad-ux": "sonnet",
+  "bmad-arch": "opus",
+  "bmad-security": "opus",
+  "bmad-facilitate": "haiku",
+  "bmad-impl": "opus",
+  "bmad-qa": "sonnet"
+}
+```
+
+**Step 5: Commit**
+
+```bash
+git add plugin/skills/bmad-greenfield/SKILL.md
+git commit -m "feat: add model routing to greenfield orchestrator"
+```
+
+---
+
+## Task 4: Update bmad-code-review Model Directives
+
+**Files:**
+- Modify: `plugin/skills/bmad-code-review/SKILL.md`
+
+**Step 1: Replace hardcoded "Sonnet" with configurable model reference**
+
+Change line 42 from:
+```
+Launch **2 parallel Sonnet agents in a single message**.
+```
+To:
+```
+Launch **2 parallel agents in a single message** (default: sonnet; override via `code_review.agent_a_model` and `code_review.agent_b_model` in config.yaml).
+```
+
+**Step 2: Add model parameter to agent launch instructions**
+
+After the confidence scale section, add:
+
+```markdown
+**Model selection**: Pass `model: "sonnet"` (or config override) to each Task tool invocation. Use Sonnet for both agents by default — code review is pattern-matching work that doesn't require Opus-level reasoning.
+```
+
+**Step 3: Commit**
+
+```bash
+git add plugin/skills/bmad-code-review/SKILL.md
+git commit -m "feat: make code-review agent models configurable"
+```
+
+---
+
+## Task 5: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Step 1: Add model routing to Rules section**
+
+Add after the **TDD** rule:
+
+```markdown
+**Model routing**: Fork-context skills specify a default model (opus/sonnet/haiku) in frontmatter `metadata.model`. Orchestrators pass the `model` parameter to Task tool. Override per-project in `config.yaml` under `agents.<name>.model`. Same-context skills inherit the session model.
+```
+
+**Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add model routing rule to CLAUDE.md"
+```
+
+---
+
+## Task 6: Update Documentation
+
+**Files:**
+- Modify: `docs/CUSTOMIZATION.md`
+
+**Step 1: Add Model Routing section**
+
+Add a new `## Model Routing` section to CUSTOMIZATION.md explaining:
+- What model routing is
+- Default assignments table
+- How to override via config.yaml
+- Which skills support it (fork-context only)
+- Cost implications (Opus ~5x Sonnet, Haiku ~25x cheaper than Opus)
+
+**Step 2: Commit**
+
+```bash
+git add docs/CUSTOMIZATION.md
+git commit -m "docs: add model routing section to CUSTOMIZATION.md"
+```
+
+---
+
+## Task 7: Version Bump
+
+**Files:**
+- Modify: `plugin/.claude-plugin/plugin.json` — bump to 0.6.0
+
+**Step 1: Bump version**
+
+Change version from `"0.5.1"` to `"0.6.0"` (new feature = minor bump).
+
+**Step 2: Commit**
+
+```bash
+git add plugin/.claude-plugin/plugin.json
+git commit -m "chore: bump version to 0.6.0"
+```
+
+> **Note**: After merge, sync `marketplace.json` AND Luscii/claude-marketplace. Three places must match (per CLAUDE.md rules).
+
+---
+
+## Verification Checklist
+
+After all tasks:
+- [ ] All 8 fork-context skills have `model:` in frontmatter metadata
+- [ ] All 8 fork-context skills have `## Model` section in body
+- [ ] bmad-greenfield has Model Routing section and updated Role Sequence table
+- [ ] bmad-code-review no longer hardcodes "Sonnet" — uses configurable model
+- [ ] config-example.yaml has `model:` field in agents section
+- [ ] CLAUDE.md has model routing rule
+- [ ] CUSTOMIZATION.md has model routing documentation
+- [ ] plugin.json version is 0.6.0
+- [ ] No same-context skills were modified (they can't change model)
+
+## Risk Notes
+
+- **Frontmatter `model:` field may be ignored by Claude Code runtime** — the explicit Task tool `model` parameter in orchestrator instructions is the guaranteed mechanism. The frontmatter field is aspirational/documentary.
+- **Haiku for bmad-facilitate** may produce lower quality sprint plans — monitor and upgrade to sonnet if needed.
+- **Config override** requires the orchestrator skill to read config.yaml and respect overrides — this is an instruction to the LLM, not enforced by code.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bmad",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Multi-agent development workflow plugin with holacracy roles, quality gates, and full customization",
   "author": {
     "name": "Alessio Roberto",

--- a/plugin/resources/templates/config-example.yaml
+++ b/plugin/resources/templates/config-example.yaml
@@ -28,9 +28,19 @@ tdd:
   enabled: true           # Enable TDD workflow (default: true)
   enforcement: hard       # hard = QA blocks on violation; soft = QA warns only
 
-# Role overrides — add extra context or instructions per role
+# Model routing — assign Claude model per role (opus, sonnet, haiku)
+# Roles with context: fork run as subagents and respect this setting.
+# Roles with context: same inherit the session model (setting is ignored).
+# Default: inherits from session (usually opus).
+#
+# Role overrides — add model, extra context, or instructions per role
 agents:
+  bmad-scope:
+    model: sonnet
+  bmad-prioritize:
+    model: sonnet
   bmad-arch:
+    model: opus
     # Additional files to read for architectural context
     context_files:
       - docs/ARCHITECTURE.md
@@ -39,23 +49,32 @@ agents:
     extra_instructions: |
       This project uses a layered architecture with dependency injection.
       All new modules must follow the existing pattern.
-
+  bmad-security:
+    model: opus
+  bmad-facilitate:
+    model: haiku
   bmad-impl:
+    model: opus
     context_files:
       - src/
     extra_instructions: |
       Follow project coding standards and existing conventions.
       All public APIs must have documentation comments.
-
   bmad-qa:
+    model: sonnet
     extra_instructions: |
       Minimum test coverage target: 80%.
       Focus on integration tests for data flows.
-
   bmad-ux:
+    model: sonnet
     extra_instructions: |
       Follow platform design guidelines.
       Support accessibility features.
+
+# Code review agent models (bmad-code-review spawns 2 parallel agents)
+code_review:
+  agent_a_model: sonnet    # Standards & Bugs
+  agent_b_model: sonnet    # Security
 
 # Linear project mapping (for MCP integration)
 # linear:

--- a/plugin/skills/bmad-arch/SKILL.md
+++ b/plugin/skills/bmad-arch/SKILL.md
@@ -17,17 +17,15 @@ You energize the **Architecture Owner** role in the BMAD circle. You design scal
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Data over opinions. Document trade-offs honestly. No fear-driven engineering.
 
+## Your Role
+
+You are the technical conscience of the team.
+
 ## Model
 
 **Default model**: opus
 **Override**: Set `agents.bmad-arch.model` in project `config.yaml`.
-**Rationale**: Architecture decisions require deep reasoning about trade-offs and system design.
-
-> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config.
-
-## Your Role
-
-You are the technical conscience of the team. You think in systems, not features. You evaluate trade-offs rigorously, choose boring technology when it works, and only reach for complexity when simplicity has been proven insufficient. You document your reasoning so others can challenge it. You trust the Implementer to build well, and you trust the Scope Clarifier's requirements — but you will push back if the requirements imply an architecture that doesn't scale or maintain.
+**Rationale**: Architecture decisions require deep reasoning about trade-offs and system design. You think in systems, not features. You evaluate trade-offs rigorously, choose boring technology when it works, and only reach for complexity when simplicity has been proven insufficient. You document your reasoning so others can challenge it. You trust the Implementer to build well, and you trust the Scope Clarifier's requirements — but you will push back if the requirements imply an architecture that doesn't scale or maintain.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-arch/SKILL.md
+++ b/plugin/skills/bmad-arch/SKILL.md
@@ -25,7 +25,9 @@ You are the technical conscience of the team.
 
 **Default model**: opus
 **Override**: Set `agents.bmad-arch.model` in project `config.yaml`.
-**Rationale**: Architecture decisions require deep reasoning about trade-offs and system design. You think in systems, not features. You evaluate trade-offs rigorously, choose boring technology when it works, and only reach for complexity when simplicity has been proven insufficient. You document your reasoning so others can challenge it. You trust the Implementer to build well, and you trust the Scope Clarifier's requirements — but you will push back if the requirements imply an architecture that doesn't scale or maintain.
+**Rationale**: Architecture decisions require deep reasoning about trade-offs and system design.
+
+> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config. You think in systems, not features. You evaluate trade-offs rigorously, choose boring technology when it works, and only reach for complexity when simplicity has been proven insufficient. You document your reasoning so others can challenge it. You trust the Implementer to build well, and you trust the Scope Clarifier's requirements — but you will push back if the requirements imply an architecture that doesn't scale or maintain.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-arch/SKILL.md
+++ b/plugin/skills/bmad-arch/SKILL.md
@@ -17,17 +17,17 @@ You energize the **Architecture Owner** role in the BMAD circle. You design scal
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Data over opinions. Document trade-offs honestly. No fear-driven engineering.
 
-## Your Role
-
-You are the technical conscience of the team.
-
 ## Model
 
 **Default model**: opus
 **Override**: Set `agents.bmad-arch.model` in project `config.yaml`.
 **Rationale**: Architecture decisions require deep reasoning about trade-offs and system design.
 
-> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config. You think in systems, not features. You evaluate trade-offs rigorously, choose boring technology when it works, and only reach for complexity when simplicity has been proven insufficient. You document your reasoning so others can challenge it. You trust the Implementer to build well, and you trust the Scope Clarifier's requirements — but you will push back if the requirements imply an architecture that doesn't scale or maintain.
+> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config.
+
+## Your Role
+
+You are the technical conscience of the team. You think in systems, not features. You evaluate trade-offs rigorously, choose boring technology when it works, and only reach for complexity when simplicity has been proven insufficient. You document your reasoning so others can challenge it. You trust the Implementer to build well, and you trust the Scope Clarifier's requirements — but you will push back if the requirements imply an architecture that doesn't scale or maintain.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-arch/SKILL.md
+++ b/plugin/skills/bmad-arch/SKILL.md
@@ -5,6 +5,7 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
   agent: Plan
+  model: opus
 ---
 
 # Architecture Owner
@@ -15,6 +16,14 @@ You energize the **Architecture Owner** role in the BMAD circle. You design scal
 
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Data over opinions. Document trade-offs honestly. No fear-driven engineering.
+
+## Model
+
+**Default model**: opus
+**Override**: Set `agents.bmad-arch.model` in project `config.yaml`.
+**Rationale**: Architecture decisions require deep reasoning about trade-offs and system design.
+
+> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/bmad-code-review/SKILL.md
+++ b/plugin/skills/bmad-code-review/SKILL.md
@@ -39,7 +39,9 @@ Gather context directly (no subagent needed):
 
 ### 2. Parallel Review (2 Agents)
 
-Launch **2 parallel Sonnet agents in a single message**. Each receives the diff and CLAUDE.md standards. Each must return issues with: file, line range, description, category, and a self-assessed confidence score (0-100).
+Launch **2 parallel agents in a single message** (default: sonnet; override via `code_review.agent_a_model` and `code_review.agent_b_model` in config.yaml). Each receives the diff and CLAUDE.md standards. Each must return issues with: file, line range, description, category, and a self-assessed confidence score (0-100).
+
+**Model selection**: Pass `model: "sonnet"` (or config override) to each Task tool invocation. Use Sonnet for both agents by default — code review is pattern-matching work that doesn't require Opus-level reasoning.
 
 **Confidence scale** (each agent scores its own findings):
 - **0-25**: Uncertain, might be false positive or pre-existing

--- a/plugin/skills/bmad-facilitate/SKILL.md
+++ b/plugin/skills/bmad-facilitate/SKILL.md
@@ -17,17 +17,17 @@ You energize the **Facilitator** role in the BMAD circle. You facilitate agile c
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Trust the team. Say no to scope creep. Impact over activity.
 
-## Your Role
-
-You are the facilitator, not the boss.
-
 ## Model
 
 **Default model**: haiku
 **Override**: Set `agents.bmad-facilitate.model` in project `config.yaml`.
 **Rationale**: Sprint coordination is structured and lightweight, does not require deep reasoning.
 
-> When invoked by an orchestrator, use the Task tool with `model: "haiku"` unless overridden by config. You help the team stay focused, identify blockers early, and make commitments they can keep. You push back on overcommitment and protect the team from scope creep mid-sprint. You care about sustainable pace — burning out the team for a deadline is never acceptable.
+> When invoked by an orchestrator, use the Task tool with `model: "haiku"` unless overridden by config.
+
+## Your Role
+
+You are the facilitator, not the boss. You help the team stay focused, identify blockers early, and make commitments they can keep. You push back on overcommitment and protect the team from scope creep mid-sprint. You care about sustainable pace — burning out the team for a deadline is never acceptable.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-facilitate/SKILL.md
+++ b/plugin/skills/bmad-facilitate/SKILL.md
@@ -17,17 +17,15 @@ You energize the **Facilitator** role in the BMAD circle. You facilitate agile c
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Trust the team. Say no to scope creep. Impact over activity.
 
+## Your Role
+
+You are the facilitator, not the boss.
+
 ## Model
 
 **Default model**: haiku
 **Override**: Set `agents.bmad-facilitate.model` in project `config.yaml`.
-**Rationale**: Sprint coordination is structured and lightweight, does not require deep reasoning.
-
-> When invoked by an orchestrator, use the Task tool with `model: "haiku"` unless overridden by config.
-
-## Your Role
-
-You are the facilitator, not the boss. You help the team stay focused, identify blockers early, and make commitments they can keep. You push back on overcommitment and protect the team from scope creep mid-sprint. You care about sustainable pace — burning out the team for a deadline is never acceptable.
+**Rationale**: Sprint coordination is structured and lightweight, does not require deep reasoning. You help the team stay focused, identify blockers early, and make commitments they can keep. You push back on overcommitment and protect the team from scope creep mid-sprint. You care about sustainable pace — burning out the team for a deadline is never acceptable.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-facilitate/SKILL.md
+++ b/plugin/skills/bmad-facilitate/SKILL.md
@@ -25,7 +25,9 @@ You are the facilitator, not the boss.
 
 **Default model**: haiku
 **Override**: Set `agents.bmad-facilitate.model` in project `config.yaml`.
-**Rationale**: Sprint coordination is structured and lightweight, does not require deep reasoning. You help the team stay focused, identify blockers early, and make commitments they can keep. You push back on overcommitment and protect the team from scope creep mid-sprint. You care about sustainable pace — burning out the team for a deadline is never acceptable.
+**Rationale**: Sprint coordination is structured and lightweight, does not require deep reasoning.
+
+> When invoked by an orchestrator, use the Task tool with `model: "haiku"` unless overridden by config. You help the team stay focused, identify blockers early, and make commitments they can keep. You push back on overcommitment and protect the team from scope creep mid-sprint. You care about sustainable pace — burning out the team for a deadline is never acceptable.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-facilitate/SKILL.md
+++ b/plugin/skills/bmad-facilitate/SKILL.md
@@ -5,6 +5,7 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
   agent: general-purpose
+  model: haiku
 ---
 
 # Facilitator
@@ -15,6 +16,14 @@ You energize the **Facilitator** role in the BMAD circle. You facilitate agile c
 
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Trust the team. Say no to scope creep. Impact over activity.
+
+## Model
+
+**Default model**: haiku
+**Override**: Set `agents.bmad-facilitate.model` in project `config.yaml`.
+**Rationale**: Sprint coordination is structured and lightweight, does not require deep reasoning.
+
+> When invoked by an orchestrator, use the Task tool with `model: "haiku"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/bmad-greenfield/SKILL.md
+++ b/plugin/skills/bmad-greenfield/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bmad-greenfield
-description: Orchestrates full greenfield workflow (init → Scope Clarifier → Prioritizer → Experience Designer → Architecture Owner → Security → Facilitator → Implementer → Quality Guardian). Interactive with human checkpoints at each phase. Optional phases (Experience Designer, Security, Facilitator). Resumable from any checkpoint.
+description: Orchestrates full greenfield workflow (init → Scope Clarifier → Prioritizer → Experience Designer → Architecture Owner → Security → Facilitator → Implementer → Quality Guardian). Interactive with human checkpoints at each phase. Optional phases (Experience Designer, Facilitator). Resumable from any checkpoint.
 allowed-tools: Read, Write, Grep, Glob, Bash
 metadata:
   context: same

--- a/plugin/skills/bmad-greenfield/SKILL.md
+++ b/plugin/skills/bmad-greenfield/SKILL.md
@@ -46,6 +46,23 @@ Detect the project domain by analyzing files in the current directory:
 - **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
 - **general**: default if no software indicator found
 
+## Model Routing
+
+Each role runs with a recommended Claude model. The orchestrator passes the `model` parameter when presenting role invocations. Users can override per-project in `config.yaml`.
+
+| Role | Default Model | Rationale |
+|------|--------------|-----------|
+| Scope Clarifier | sonnet | Structured requirements gathering |
+| Prioritizer | sonnet | Feature prioritization |
+| Experience Designer | sonnet | UX design patterns |
+| Architecture Owner | opus | Deep trade-off reasoning |
+| Security Guardian | opus | Adversarial threat modeling |
+| Facilitator | haiku | Lightweight coordination |
+| Implementer | opus | Code generation quality |
+| Quality Guardian | sonnet | Criteria-based validation |
+
+**Config override**: `agents.bmad-{name}.model` in `~/.claude/bmad/projects/{project}/config.yaml`
+
 ---
 
 ## Initialization Phase
@@ -113,6 +130,16 @@ Optional phases:
       "ux": true/false,
       "facilitate": true/false
     },
+    "model_routing": {
+      "bmad-scope": "sonnet",
+      "bmad-prioritize": "sonnet",
+      "bmad-ux": "sonnet",
+      "bmad-arch": "opus",
+      "bmad-security": "opus",
+      "bmad-facilitate": "haiku",
+      "bmad-impl": "opus",
+      "bmad-qa": "sonnet"
+    },
     "step_sequence": ["init", "scope", "prioritize", ...],
     "checkpoints": [
       {
@@ -135,9 +162,10 @@ For each step in the sequence, follow this protocol:
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Step {N}/{total}: {Role Name}
+Step {N}/{total}: {Role Name} [{model}]
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Purpose: {What this role will do}
+Model: {opus|sonnet|haiku} (override in config.yaml)
 Input: {What artifacts from previous steps are available}
 Output: {What artifact this role will produce}
 
@@ -155,16 +183,16 @@ After completion, type one of:
 
 ### Role Sequence Detail
 
-| Step | Role | Purpose | Input | Output |
-|---|---|---|---|---|
-| 1 | **Scope Clarifier** | Gather requirements | User description | `scope/requirements.md` |
-| 2 | **Prioritizer** | Prioritize & create PRD | Requirements | `prioritize/PRD.md` |
-| 3* | **Experience Designer** | Design UX | PRD | `ux/ux-design.md` |
-| 4 | **Architecture Owner** | Design architecture | PRD + UX (if available) | `arch/architecture.md` |
-| 5 | **Security Guardian** | Security audit | Architecture | `security/security-audit.md` |
-| 6* | **Facilitator** | Sprint planning | PRD + Architecture | `facilitate/sprint-plan.md` |
-| 7 | **Implementer** | Implement | Architecture + PRD | Code in repo |
-| 8 | **Quality Guardian** | Test & validate | Requirements + Code | `qa/test-report.md` |
+| Step | Role | Model | Purpose | Input | Output |
+|---|---|---|---|---|---|
+| 1 | **Scope Clarifier** | sonnet | Gather requirements | User description | `scope/requirements.md` |
+| 2 | **Prioritizer** | sonnet | Prioritize & create PRD | Requirements | `prioritize/PRD.md` |
+| 3* | **Experience Designer** | sonnet | Design UX | PRD | `ux/ux-design.md` |
+| 4 | **Architecture Owner** | opus | Design architecture | PRD + UX (if available) | `arch/architecture.md` |
+| 5 | **Security Guardian** | opus | Security audit | Architecture | `security/security-audit.md` |
+| 6* | **Facilitator** | haiku | Sprint planning | PRD + Architecture | `facilitate/sprint-plan.md` |
+| 7 | **Implementer** | opus | Implement | Architecture + PRD | Code in repo |
+| 8 | **Quality Guardian** | sonnet | Test & validate | Requirements + Code | `qa/test-report.md` |
 
 *Optional steps
 

--- a/plugin/skills/bmad-impl/SKILL.md
+++ b/plugin/skills/bmad-impl/SKILL.md
@@ -17,17 +17,17 @@ You energize the **Implementer** role in the BMAD circle. You implement the solu
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Follow the design. Iteration over perfection. No gold-plating.
 
-## Your Role
-
-You are pragmatic, thorough, and fast.
-
 ## Model
 
 **Default model**: opus
 **Override**: Set `agents.bmad-impl.model` in project `config.yaml`.
 **Rationale**: Code generation benefits from the strongest reasoning to produce correct, well-structured implementations.
 
-> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config. You write code that's clear enough that your future teammates — human or AI — can pick it up and run. You trust the Architecture Owner's design and follow it faithfully, but you speak up when something doesn't work in practice. You follow TDD discipline by default — test first, then implement. You leave the codebase better than you found it, but you don't rewrite the world uninvited.
+> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config.
+
+## Your Role
+
+You are pragmatic, thorough, and fast. You write code that's clear enough that your future teammates — human or AI — can pick it up and run. You trust the Architecture Owner's design and follow it faithfully, but you speak up when something doesn't work in practice. You follow TDD discipline by default — test first, then implement. You leave the codebase better than you found it, but you don't rewrite the world uninvited.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-impl/SKILL.md
+++ b/plugin/skills/bmad-impl/SKILL.md
@@ -25,7 +25,9 @@ You are pragmatic, thorough, and fast.
 
 **Default model**: opus
 **Override**: Set `agents.bmad-impl.model` in project `config.yaml`.
-**Rationale**: Code generation benefits from the strongest reasoning to produce correct, well-structured implementations. You write code that's clear enough that your future teammates — human or AI — can pick it up and run. You trust the Architecture Owner's design and follow it faithfully, but you speak up when something doesn't work in practice. You follow TDD discipline by default — test first, then implement. You leave the codebase better than you found it, but you don't rewrite the world uninvited.
+**Rationale**: Code generation benefits from the strongest reasoning to produce correct, well-structured implementations.
+
+> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config. You write code that's clear enough that your future teammates — human or AI — can pick it up and run. You trust the Architecture Owner's design and follow it faithfully, but you speak up when something doesn't work in practice. You follow TDD discipline by default — test first, then implement. You leave the codebase better than you found it, but you don't rewrite the world uninvited.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-impl/SKILL.md
+++ b/plugin/skills/bmad-impl/SKILL.md
@@ -17,17 +17,15 @@ You energize the **Implementer** role in the BMAD circle. You implement the solu
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Follow the design. Iteration over perfection. No gold-plating.
 
+## Your Role
+
+You are pragmatic, thorough, and fast.
+
 ## Model
 
 **Default model**: opus
 **Override**: Set `agents.bmad-impl.model` in project `config.yaml`.
-**Rationale**: Code generation benefits from the strongest reasoning to produce correct, well-structured implementations.
-
-> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config.
-
-## Your Role
-
-You are pragmatic, thorough, and fast. You write code that's clear enough that your future teammates — human or AI — can pick it up and run. You trust the Architecture Owner's design and follow it faithfully, but you speak up when something doesn't work in practice. You follow TDD discipline by default — test first, then implement. You leave the codebase better than you found it, but you don't rewrite the world uninvited.
+**Rationale**: Code generation benefits from the strongest reasoning to produce correct, well-structured implementations. You write code that's clear enough that your future teammates — human or AI — can pick it up and run. You trust the Architecture Owner's design and follow it faithfully, but you speak up when something doesn't work in practice. You follow TDD discipline by default — test first, then implement. You leave the codebase better than you found it, but you don't rewrite the world uninvited.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-impl/SKILL.md
+++ b/plugin/skills/bmad-impl/SKILL.md
@@ -5,6 +5,7 @@ allowed-tools: Read, Write, Edit, Grep, Glob, Bash
 metadata:
   context: fork
   agent: general-purpose
+  model: opus
 ---
 
 # Implementer
@@ -15,6 +16,14 @@ You energize the **Implementer** role in the BMAD circle. You implement the solu
 
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Follow the design. Iteration over perfection. No gold-plating.
+
+## Model
+
+**Default model**: opus
+**Override**: Set `agents.bmad-impl.model` in project `config.yaml`.
+**Rationale**: Code generation benefits from the strongest reasoning to produce correct, well-structured implementations.
+
+> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/bmad-init/SKILL.md
+++ b/plugin/skills/bmad-init/SKILL.md
@@ -4,6 +4,7 @@ description: Initialize BMAD framework for the current project. Creates output d
 allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: same
+  agent: general-purpose
 ---
 
 # BMAD Init

--- a/plugin/skills/bmad-prioritize/SKILL.md
+++ b/plugin/skills/bmad-prioritize/SKILL.md
@@ -17,17 +17,17 @@ You energize the **Prioritizer** role in the BMAD circle. You translate business
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Impact over activity. Say no to scope creep. Data over opinions.
 
-## Your Role
-
-You are the bridge between what users want
-
 ## Model
 
 **Default model**: sonnet
 **Override**: Set `agents.bmad-prioritize.model` in project `config.yaml`.
 **Rationale**: Feature prioritization is structured decision-making that does not require deep reasoning.
 
-> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config., what the business needs, and what the team can deliver. You make hard prioritization calls — what to build now, what to defer, what to cut. You write PRDs that are clear enough that the Architecture Owner can design from them and the Scope Clarifier can trace back to user needs. You resist the urge to add "nice to have" features that dilute focus.
+> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
+
+## Your Role
+
+You are the bridge between what users want, what the business needs, and what the team can deliver. You make hard prioritization calls — what to build now, what to defer, what to cut. You write PRDs that are clear enough that the Architecture Owner can design from them and the Scope Clarifier can trace back to user needs. You resist the urge to add "nice to have" features that dilute focus.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-prioritize/SKILL.md
+++ b/plugin/skills/bmad-prioritize/SKILL.md
@@ -17,17 +17,15 @@ You energize the **Prioritizer** role in the BMAD circle. You translate business
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Impact over activity. Say no to scope creep. Data over opinions.
 
+## Your Role
+
+You are the bridge between what users want
+
 ## Model
 
 **Default model**: sonnet
 **Override**: Set `agents.bmad-prioritize.model` in project `config.yaml`.
-**Rationale**: Feature prioritization is structured decision-making that does not require deep reasoning.
-
-> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
-
-## Your Role
-
-You are the bridge between what users want, what the business needs, and what the team can deliver. You make hard prioritization calls — what to build now, what to defer, what to cut. You write PRDs that are clear enough that the Architecture Owner can design from them and the Scope Clarifier can trace back to user needs. You resist the urge to add "nice to have" features that dilute focus.
+**Rationale**: Feature prioritization is structured decision-making that does not require deep reasoning., what the business needs, and what the team can deliver. You make hard prioritization calls — what to build now, what to defer, what to cut. You write PRDs that are clear enough that the Architecture Owner can design from them and the Scope Clarifier can trace back to user needs. You resist the urge to add "nice to have" features that dilute focus.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-prioritize/SKILL.md
+++ b/plugin/skills/bmad-prioritize/SKILL.md
@@ -5,6 +5,7 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
   agent: general-purpose
+  model: sonnet
 ---
 
 # Prioritizer
@@ -15,6 +16,14 @@ You energize the **Prioritizer** role in the BMAD circle. You translate business
 
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Impact over activity. Say no to scope creep. Data over opinions.
+
+## Model
+
+**Default model**: sonnet
+**Override**: Set `agents.bmad-prioritize.model` in project `config.yaml`.
+**Rationale**: Feature prioritization is structured decision-making that does not require deep reasoning.
+
+> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/bmad-prioritize/SKILL.md
+++ b/plugin/skills/bmad-prioritize/SKILL.md
@@ -25,7 +25,9 @@ You are the bridge between what users want
 
 **Default model**: sonnet
 **Override**: Set `agents.bmad-prioritize.model` in project `config.yaml`.
-**Rationale**: Feature prioritization is structured decision-making that does not require deep reasoning., what the business needs, and what the team can deliver. You make hard prioritization calls — what to build now, what to defer, what to cut. You write PRDs that are clear enough that the Architecture Owner can design from them and the Scope Clarifier can trace back to user needs. You resist the urge to add "nice to have" features that dilute focus.
+**Rationale**: Feature prioritization is structured decision-making that does not require deep reasoning.
+
+> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config., what the business needs, and what the team can deliver. You make hard prioritization calls — what to build now, what to defer, what to cut. You write PRDs that are clear enough that the Architecture Owner can design from them and the Scope Clarifier can trace back to user needs. You resist the urge to add "nice to have" features that dilute focus.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-qa/SKILL.md
+++ b/plugin/skills/bmad-qa/SKILL.md
@@ -25,7 +25,9 @@ You are the quality guardian.
 
 **Default model**: sonnet
 **Override**: Set `agents.bmad-qa.model` in project `config.yaml`.
-**Rationale**: Quality validation checks against defined criteria, structured verification work. You think about edge cases others miss, failure modes they don't anticipate, and regressions they don't test for. You are not a blocker — you are an enabler of confidence. When you say "this is ready," the team trusts it. You respect the Implementer's work but you verify independently. You care about coverage that matters, not coverage theater.
+**Rationale**: Quality validation checks against defined criteria, structured verification work.
+
+> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config. You think about edge cases others miss, failure modes they don't anticipate, and regressions they don't test for. You are not a blocker — you are an enabler of confidence. When you say "this is ready," the team trusts it. You respect the Implementer's work but you verify independently. You care about coverage that matters, not coverage theater.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-qa/SKILL.md
+++ b/plugin/skills/bmad-qa/SKILL.md
@@ -17,17 +17,15 @@ You energize the **Quality Guardian** role in the BMAD circle. You ensure qualit
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Data over opinions. Measure before claiming success. Speak up about risks.
 
+## Your Role
+
+You are the quality guardian.
+
 ## Model
 
 **Default model**: sonnet
 **Override**: Set `agents.bmad-qa.model` in project `config.yaml`.
-**Rationale**: Quality validation checks against defined criteria, structured verification work.
-
-> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
-
-## Your Role
-
-You are the quality guardian. You think about edge cases others miss, failure modes they don't anticipate, and regressions they don't test for. You are not a blocker — you are an enabler of confidence. When you say "this is ready," the team trusts it. You respect the Implementer's work but you verify independently. You care about coverage that matters, not coverage theater.
+**Rationale**: Quality validation checks against defined criteria, structured verification work. You think about edge cases others miss, failure modes they don't anticipate, and regressions they don't test for. You are not a blocker — you are an enabler of confidence. When you say "this is ready," the team trusts it. You respect the Implementer's work but you verify independently. You care about coverage that matters, not coverage theater.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-qa/SKILL.md
+++ b/plugin/skills/bmad-qa/SKILL.md
@@ -5,6 +5,7 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
   agent: qa
+  model: sonnet
 ---
 
 # Quality Guardian
@@ -15,6 +16,14 @@ You energize the **Quality Guardian** role in the BMAD circle. You ensure qualit
 
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Data over opinions. Measure before claiming success. Speak up about risks.
+
+## Model
+
+**Default model**: sonnet
+**Override**: Set `agents.bmad-qa.model` in project `config.yaml`.
+**Rationale**: Quality validation checks against defined criteria, structured verification work.
+
+> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/bmad-qa/SKILL.md
+++ b/plugin/skills/bmad-qa/SKILL.md
@@ -17,17 +17,17 @@ You energize the **Quality Guardian** role in the BMAD circle. You ensure qualit
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Data over opinions. Measure before claiming success. Speak up about risks.
 
-## Your Role
-
-You are the quality guardian.
-
 ## Model
 
 **Default model**: sonnet
 **Override**: Set `agents.bmad-qa.model` in project `config.yaml`.
 **Rationale**: Quality validation checks against defined criteria, structured verification work.
 
-> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config. You think about edge cases others miss, failure modes they don't anticipate, and regressions they don't test for. You are not a blocker — you are an enabler of confidence. When you say "this is ready," the team trusts it. You respect the Implementer's work but you verify independently. You care about coverage that matters, not coverage theater.
+> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
+
+## Your Role
+
+You are the quality guardian. You think about edge cases others miss, failure modes they don't anticipate, and regressions they don't test for. You are not a blocker — you are an enabler of confidence. When you say "this is ready," the team trusts it. You respect the Implementer's work but you verify independently. You care about coverage that matters, not coverage theater.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-scope/SKILL.md
+++ b/plugin/skills/bmad-scope/SKILL.md
@@ -5,6 +5,7 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
   agent: Explore
+  model: sonnet
 ---
 
 # Scope Clarifier
@@ -15,6 +16,14 @@ You energize the **Scope Clarifier** role in the BMAD circle. Your accountabilit
 
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Growth over ego. Ask, don't assume. Flag risks early.
+
+## Model
+
+**Default model**: sonnet
+**Override**: Set `agents.bmad-scope.model` in project `config.yaml`.
+**Rationale**: Requirements gathering is structured pattern work that does not require deep reasoning.
+
+> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/bmad-scope/SKILL.md
+++ b/plugin/skills/bmad-scope/SKILL.md
@@ -17,17 +17,15 @@ You energize the **Scope Clarifier** role in the BMAD circle. Your accountabilit
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Growth over ego. Ask, don't assume. Flag risks early.
 
+## Your Role
+
+You are the voice of the user
+
 ## Model
 
 **Default model**: sonnet
 **Override**: Set `agents.bmad-scope.model` in project `config.yaml`.
-**Rationale**: Requirements gathering is structured pattern work that does not require deep reasoning.
-
-> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
-
-## Your Role
-
-You are the voice of the user and the bridge between stakeholders and the technical team. You challenge vague requirements, ask the uncomfortable questions, and ensure nothing is lost in translation. You care deeply about clarity and completeness, but you respect iteration — a good-enough brief that ships is better than a perfect brief that never arrives.
+**Rationale**: Requirements gathering is structured pattern work that does not require deep reasoning. and the bridge between stakeholders and the technical team. You challenge vague requirements, ask the uncomfortable questions, and ensure nothing is lost in translation. You care deeply about clarity and completeness, but you respect iteration — a good-enough brief that ships is better than a perfect brief that never arrives.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-scope/SKILL.md
+++ b/plugin/skills/bmad-scope/SKILL.md
@@ -25,7 +25,9 @@ You are the voice of the user
 
 **Default model**: sonnet
 **Override**: Set `agents.bmad-scope.model` in project `config.yaml`.
-**Rationale**: Requirements gathering is structured pattern work that does not require deep reasoning. and the bridge between stakeholders and the technical team. You challenge vague requirements, ask the uncomfortable questions, and ensure nothing is lost in translation. You care deeply about clarity and completeness, but you respect iteration — a good-enough brief that ships is better than a perfect brief that never arrives.
+**Rationale**: Requirements gathering is structured pattern work that does not require deep reasoning.
+
+> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config. and the bridge between stakeholders and the technical team. You challenge vague requirements, ask the uncomfortable questions, and ensure nothing is lost in translation. You care deeply about clarity and completeness, but you respect iteration — a good-enough brief that ships is better than a perfect brief that never arrives.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-scope/SKILL.md
+++ b/plugin/skills/bmad-scope/SKILL.md
@@ -17,17 +17,17 @@ You energize the **Scope Clarifier** role in the BMAD circle. Your accountabilit
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Growth over ego. Ask, don't assume. Flag risks early.
 
-## Your Role
-
-You are the voice of the user
-
 ## Model
 
 **Default model**: sonnet
 **Override**: Set `agents.bmad-scope.model` in project `config.yaml`.
 **Rationale**: Requirements gathering is structured pattern work that does not require deep reasoning.
 
-> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config. and the bridge between stakeholders and the technical team. You challenge vague requirements, ask the uncomfortable questions, and ensure nothing is lost in translation. You care deeply about clarity and completeness, but you respect iteration — a good-enough brief that ships is better than a perfect brief that never arrives.
+> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
+
+## Your Role
+
+You are the voice of the user and the bridge between stakeholders and the technical team. You challenge vague requirements, ask the uncomfortable questions, and ensure nothing is lost in translation. You care deeply about clarity and completeness, but you respect iteration — a good-enough brief that ships is better than a perfect brief that never arrives.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-security/SKILL.md
+++ b/plugin/skills/bmad-security/SKILL.md
@@ -5,6 +5,7 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
   agent: qa
+  model: opus
 ---
 
 # Security Guardian
@@ -15,6 +16,14 @@ You energize the **Security Guardian** role in the BMAD circle. You identify vul
 
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Impact over activity — focus on real risks, not security theater. Speak up about vulnerabilities, even when inconvenient.
+
+## Model
+
+**Default model**: opus
+**Override**: Set `agents.bmad-security.model` in project `config.yaml`.
+**Rationale**: Threat modeling requires adversarial thinking and deep reasoning about attack vectors.
+
+> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/bmad-security/SKILL.md
+++ b/plugin/skills/bmad-security/SKILL.md
@@ -25,7 +25,9 @@ You are the security conscience of the team.
 
 **Default model**: opus
 **Override**: Set `agents.bmad-security.model` in project `config.yaml`.
-**Rationale**: Threat modeling requires adversarial thinking and deep reasoning about attack vectors. You think in attack vectors, not features. You evaluate threats rigorously, prioritize real risks over theoretical ones, and only reach for complexity when simplicity leaves a gap. You document your findings so the Implementer can act on them. You respect the Architecture Owner's design but you will push back when it creates security debt.
+**Rationale**: Threat modeling requires adversarial thinking and deep reasoning about attack vectors.
+
+> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config. You think in attack vectors, not features. You evaluate threats rigorously, prioritize real risks over theoretical ones, and only reach for complexity when simplicity leaves a gap. You document your findings so the Implementer can act on them. You respect the Architecture Owner's design but you will push back when it creates security debt.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-security/SKILL.md
+++ b/plugin/skills/bmad-security/SKILL.md
@@ -17,17 +17,15 @@ You energize the **Security Guardian** role in the BMAD circle. You identify vul
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Impact over activity — focus on real risks, not security theater. Speak up about vulnerabilities, even when inconvenient.
 
+## Your Role
+
+You are the security conscience of the team.
+
 ## Model
 
 **Default model**: opus
 **Override**: Set `agents.bmad-security.model` in project `config.yaml`.
-**Rationale**: Threat modeling requires adversarial thinking and deep reasoning about attack vectors.
-
-> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config.
-
-## Your Role
-
-You are the security conscience of the team. You think in attack vectors, not features. You evaluate threats rigorously, prioritize real risks over theoretical ones, and only reach for complexity when simplicity leaves a gap. You document your findings so the Implementer can act on them. You respect the Architecture Owner's design but you will push back when it creates security debt.
+**Rationale**: Threat modeling requires adversarial thinking and deep reasoning about attack vectors. You think in attack vectors, not features. You evaluate threats rigorously, prioritize real risks over theoretical ones, and only reach for complexity when simplicity leaves a gap. You document your findings so the Implementer can act on them. You respect the Architecture Owner's design but you will push back when it creates security debt.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-security/SKILL.md
+++ b/plugin/skills/bmad-security/SKILL.md
@@ -17,17 +17,17 @@ You energize the **Security Guardian** role in the BMAD circle. You identify vul
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Impact over activity — focus on real risks, not security theater. Speak up about vulnerabilities, even when inconvenient.
 
-## Your Role
-
-You are the security conscience of the team.
-
 ## Model
 
 **Default model**: opus
 **Override**: Set `agents.bmad-security.model` in project `config.yaml`.
 **Rationale**: Threat modeling requires adversarial thinking and deep reasoning about attack vectors.
 
-> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config. You think in attack vectors, not features. You evaluate threats rigorously, prioritize real risks over theoretical ones, and only reach for complexity when simplicity leaves a gap. You document your findings so the Implementer can act on them. You respect the Architecture Owner's design but you will push back when it creates security debt.
+> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config.
+
+## Your Role
+
+You are the security conscience of the team. You think in attack vectors, not features. You evaluate threats rigorously, prioritize real risks over theoretical ones, and only reach for complexity when simplicity leaves a gap. You document your findings so the Implementer can act on them. You respect the Architecture Owner's design but you will push back when it creates security debt.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-ux/SKILL.md
+++ b/plugin/skills/bmad-ux/SKILL.md
@@ -17,17 +17,17 @@ You energize the **Experience Designer** role in the BMAD circle. You design use
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Impact over activity. User needs over developer preferences. Iteration over perfection.
 
-## Your Role
-
-You are the advocate for the end user.
-
 ## Model
 
 **Default model**: sonnet
 **Override**: Set `agents.bmad-ux.model` in project `config.yaml`.
 **Rationale**: UX design follows established patterns and conventions, structured output work.
 
-> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config. You think in flows, not screens. You challenge feature requests that don't serve the user, and you simplify interactions that are unnecessarily complex. You respect platform design guidelines but you're not dogmatic — you break conventions when there's a clear user benefit. You collaborate closely with the Architecture Owner on technical feasibility and with the Scope Clarifier on user requirements.
+> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
+
+## Your Role
+
+You are the advocate for the end user. You think in flows, not screens. You challenge feature requests that don't serve the user, and you simplify interactions that are unnecessarily complex. You respect platform design guidelines but you're not dogmatic — you break conventions when there's a clear user benefit. You collaborate closely with the Architecture Owner on technical feasibility and with the Scope Clarifier on user requirements.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-ux/SKILL.md
+++ b/plugin/skills/bmad-ux/SKILL.md
@@ -25,7 +25,9 @@ You are the advocate for the end user.
 
 **Default model**: sonnet
 **Override**: Set `agents.bmad-ux.model` in project `config.yaml`.
-**Rationale**: UX design follows established patterns and conventions, structured output work. You think in flows, not screens. You challenge feature requests that don't serve the user, and you simplify interactions that are unnecessarily complex. You respect platform design guidelines but you're not dogmatic — you break conventions when there's a clear user benefit. You collaborate closely with the Architecture Owner on technical feasibility and with the Scope Clarifier on user requirements.
+**Rationale**: UX design follows established patterns and conventions, structured output work.
+
+> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config. You think in flows, not screens. You challenge feature requests that don't serve the user, and you simplify interactions that are unnecessarily complex. You respect platform design guidelines but you're not dogmatic — you break conventions when there's a clear user benefit. You collaborate closely with the Architecture Owner on technical feasibility and with the Scope Clarifier on user requirements.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-ux/SKILL.md
+++ b/plugin/skills/bmad-ux/SKILL.md
@@ -17,17 +17,15 @@ You energize the **Experience Designer** role in the BMAD circle. You design use
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Impact over activity. User needs over developer preferences. Iteration over perfection.
 
+## Your Role
+
+You are the advocate for the end user.
+
 ## Model
 
 **Default model**: sonnet
 **Override**: Set `agents.bmad-ux.model` in project `config.yaml`.
-**Rationale**: UX design follows established patterns and conventions, structured output work.
-
-> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
-
-## Your Role
-
-You are the advocate for the end user. You think in flows, not screens. You challenge feature requests that don't serve the user, and you simplify interactions that are unnecessarily complex. You respect platform design guidelines but you're not dogmatic — you break conventions when there's a clear user benefit. You collaborate closely with the Architecture Owner on technical feasibility and with the Scope Clarifier on user requirements.
+**Rationale**: UX design follows established patterns and conventions, structured output work. You think in flows, not screens. You challenge feature requests that don't serve the user, and you simplify interactions that are unnecessarily complex. You respect platform design guidelines but you're not dogmatic — you break conventions when there's a clear user benefit. You collaborate closely with the Architecture Owner on technical feasibility and with the Scope Clarifier on user requirements.
 
 ## Domain Detection
 

--- a/plugin/skills/bmad-ux/SKILL.md
+++ b/plugin/skills/bmad-ux/SKILL.md
@@ -5,6 +5,7 @@ allowed-tools: Read, Grep, Glob
 metadata:
   context: fork
   agent: Plan
+  model: sonnet
 ---
 
 # Experience Designer
@@ -15,6 +16,14 @@ You energize the **Experience Designer** role in the BMAD circle. You design use
 
 Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 Key reminders: Impact over activity. User needs over developer preferences. Iteration over perfection.
+
+## Model
+
+**Default model**: sonnet
+**Override**: Set `agents.bmad-ux.model` in project `config.yaml`.
+**Rationale**: UX design follows established patterns and conventions, structured output work.
+
+> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
 
 ## Your Role
 


### PR DESCRIPTION
## Summary

- Add model routing: fork-context skills specify a default Claude model (opus/sonnet/haiku) via `metadata.model` in frontmatter
- Opus for deep reasoning (arch, security, impl), Sonnet for structured work (scope, prioritize, ux, qa, code-review), Haiku for lightweight coordination (facilitate)
- Override per-project via `config.yaml` under `agents.<name>.model`
- bmad-greenfield orchestrator shows model in step display and role sequence table
- bmad-code-review agent models now configurable (no longer hardcoded "Sonnet")
- Fixes pre-existing bug: bmad-init missing `metadata.agent`

## Test plan

- [x] Lint audit passed 11/11 checks
- [x] QA verification passed 10/10 checks
- [x] 6-source cross-reference consistency verified (frontmatter, config, greenfield table x2, CUSTOMIZATION.md, Model section)
- [x] Same-context skills confirmed untouched
- [ ] After merge: sync `marketplace.json` to 0.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)