### PR TITLE
feat: add bmad-validate-prd skill (v0.7.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,9 @@
   "plugins": [
     {
       "name": "bmad",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "source": "./plugin",
-      "description": "16 skills (9 holacracy roles + 7 utilities) with structured workflows, quality gates, TDD enforcement, security audits, and full customization"
+      "description": "17 skills (9 holacracy roles + 8 utilities) with structured workflows, quality gates, TDD enforcement, security audits, and full customization"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # BMAD Plugin
 
-Pure Markdown plugin for Claude Code. 16 skills (9 holacracy roles + 7 utilities). No build, no tests, no CI.
+Pure Markdown plugin for Claude Code. 17 skills (9 holacracy roles + 8 utilities). No build, no tests, no CI.
 
 ## Dev
 
@@ -18,7 +18,7 @@ plugin/resources/soul.md               # Shared principles — every role loads 
 plugin/resources/deps-manifest.yaml    # Dependency registry (source of truth)
 plugin/resources/scripts/              # install-deps.sh, update-deps.sh
 plugin/resources/templates/{docs,software}/ # Output templates
-plugin/skills/bmad-*/SKILL.md          # 16 skills (see ls)
+plugin/skills/bmad-*/SKILL.md          # 17 skills (see ls)
 docs/                                  # CUSTOMIZATION.md, GETTING-STARTED.md, MIGRATION.md
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These run multi-step workflows, guiding you through each phase with decision poi
 
 | Command | What it does |
 |---|---|
-| `/bmad:bmad-greenfield` | Runs the full workflow: Scope Clarifier (requirements) → Prioritizer (product plan) → Experience Designer (design) → Architecture Owner (architecture) → Security review → Facilitator (sprint plan) → Implementer (code) → Quality Guardian (tests). You can skip optional steps. |
+| `/bmad:bmad-greenfield` | Runs the full workflow: Scope Clarifier (requirements) → Prioritizer (product plan) → PRD Validator (quality check) → Experience Designer (design) → Architecture Owner (architecture) → Security review → Facilitator (sprint plan) → Implementer (code) → Quality Guardian (tests). You can skip optional steps. |
 | `/bmad:bmad-sprint` | Interactive sprint planning ceremony — 6 steps from backlog review to sprint commitment |
 
 ## Utilities
@@ -48,6 +48,7 @@ These run multi-step workflows, guiding you through each phase with decision poi
 | Command | What it does |
 |---|---|
 | `/bmad:bmad-init` | Sets up BMAD for your current project. Run this once per project. Checks for optional tools and offers to install them. |
+| `/bmad:bmad-validate-prd` | Validates PRD quality against 8 structured checks. Use after creating a PRD, before architecture design |
 | `/bmad:bmad-tdd` | Enforces strict red-green-refactor TDD cycle. Write a failing test, make it pass, refactor. Used standalone or as sub-workflow of the Implementer |
 | `/bmad:bmad-shard` | Splits large documents into smaller pieces (called "shards") so roles can work with just the part they need — reduces token usage by ~90% |
 | `/bmad:bmad` | Shows project status: what phase you're in, what's been done, and what roles are available |
@@ -146,6 +147,7 @@ Each work role runs in its own isolated context — it starts fresh every time w
 
 Built-in safety checks prevent the workflow from advancing when something isn't right:
 
+- **PRD Validation Gate**: If PRD validation fails, the workflow loops back to the Prioritizer for fixes before architecture begins
 - **Security Block**: The greenfield orchestrator won't move to implementation if critical security issues are found
 - **QA Reject Gate**: If the Quality Guardian rejects the implementation, the workflow sends it back to the Implementer for fixes
 - **TDD Compliance**: The Quality Guardian verifies commit history follows the `test(red):` → `feat(green):` → `refactor:` pattern. Hard enforcement blocks merge; soft enforcement warns only
@@ -205,7 +207,7 @@ Drop a `.md` in `plugin/resources/templates/docs/` or `software/`.
 
 ### New Feature
 ```
-Scope Clarifier → Prioritizer → [Experience Designer] → Architecture Owner → [Security] → [Facilitator] → Implementer (with TDD) → Quality Guardian
+Scope Clarifier → Prioritizer → [PRD Validator] → [Experience Designer] → Architecture Owner → [Security] → [Facilitator] → Implementer (with TDD) → Quality Guardian
 ```
 Steps in brackets are optional.
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -98,7 +98,7 @@ The greenfield command runs the entire process from start to finish, with you ma
 /bmad:bmad-greenfield
 ```
 
-This walks through: Scope Clarifier (requirements) → Prioritizer (product plan) → Experience Designer (design) → Architecture Owner (architecture) → Security Guardian (security audit) → Facilitator (sprint planning) → Implementer (implementation with TDD) → Quality Guardian (testing + TDD compliance). You can skip optional steps.
+This walks through: Scope Clarifier (requirements) → Prioritizer (product plan) → PRD Validator (quality check) → Experience Designer (design) → Architecture Owner (architecture) → Security Guardian (security audit) → Facilitator (sprint planning) → Implementer (implementation with TDD) → Quality Guardian (testing + TDD compliance). You can skip optional steps.
 
 ## Available commands
 
@@ -119,6 +119,7 @@ Every command starts with `/bmad:`. Just type it and press Enter.
 | `/bmad:bmad-sprint` | Run a sprint planning session |
 | `/bmad:bmad-code-review` | Review a pull request |
 | `/bmad:bmad-triage` | Handle review feedback on a pull request |
+| `/bmad:bmad-validate-prd` | Validate PRD quality before architecture design |
 | `/bmad:bmad-tdd` | Enforce test-driven development (red-green-refactor cycle) |
 | `/bmad:bmad-shard` | Split large documents into smaller pieces (saves time and cost) |
 | `/bmad:bmad-init` | Set up BMAD for your current project (run once) |

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -11,8 +11,8 @@ This guide covers migrating from the original BMAD-Setup (global slash commands 
 | `~/.claude/commands/bmad-init.md` | Plugin skill: `/bmad:bmad-init` |
 | `~/.claude/commands/bmad-remove.md` | Not needed (zero footprint by default) |
 | `~/Documents/BMAD-Setup/soul.md` | `plugin/resources/soul.md` |
-| `~/Documents/BMAD-Setup/bmad-section-template.md` | Distributed across 16 SKILL.md files |
-| Single conversation role-playing | Real role isolation (`context: fork`) via 16 SKILL.md files |
+| `~/Documents/BMAD-Setup/bmad-section-template.md` | Distributed across 17 SKILL.md files |
+| Single conversation role-playing | Real role isolation (`context: fork`) via 17 SKILL.md files |
 | No state persistence | `session-state.json` with pause/resume |
 | No quality gates | P0 blocks + QA reject gates |
 | No token management | Context sharding via `/bmad:bmad-shard` |
@@ -167,6 +167,7 @@ mv ~/Documents/BMAD-Setup ~/Documents/BMAD-Setup-archived
 | N/A | `/bmad:bmad-triage` (review comment handler) |
 | N/A | `/bmad:bmad-sprint` (sprint ceremony) |
 | N/A | `/bmad:bmad-shard` (context sharding) |
+| N/A | `/bmad:bmad-validate-prd` (PRD validation) |
 | N/A | `/bmad:bmad-tdd` (TDD enforcement) |
 | N/A | `/bmad:bmad` (status dashboard) |
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bmad",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Multi-agent development workflow plugin with holacracy roles, quality gates, and full customization",
   "author": {
     "name": "Alessio Roberto",

--- a/plugin/commands/bmad.md
+++ b/plugin/commands/bmad.md
@@ -53,9 +53,10 @@ Review:
   /bmad-triage      — Handle review feedback
 
 Utilities:
-  /bmad-tdd   — TDD red-green-refactor enforcer
-  /bmad-init  — Set up BMAD for this project
-  /bmad-shard — Split large docs for faster processing
+  /bmad-validate-prd — PRD quality validation (8 checks)
+  /bmad-tdd          — TDD red-green-refactor enforcer
+  /bmad-init         — Set up BMAD for this project
+  /bmad-shard        — Split large docs for faster processing
 
 Tip: Type /bmad detailed for version info and dependency status.
 ```

--- a/plugin/resources/templates/config-example.yaml
+++ b/plugin/resources/templates/config-example.yaml
@@ -18,6 +18,7 @@
 greenfield_defaults:
   ux: true
   facilitate: false
+  validate_prd: false    # PRD quality validation after prioritize
 
 # Test-Driven Development (TDD) enforcement
 # TDD is enabled by default. bmad-impl uses red-green-refactor cycle via bmad-tdd
@@ -49,6 +50,8 @@ agents:
     extra_instructions: |
       This project uses a layered architecture with dependency injection.
       All new modules must follow the existing pattern.
+  bmad-validate-prd:
+    model: sonnet
   bmad-security:
     model: opus
   bmad-facilitate:

--- a/plugin/skills/bmad-greenfield/SKILL.md
+++ b/plugin/skills/bmad-greenfield/SKILL.md
@@ -109,9 +109,9 @@ Domain: {detected domain}
 Mandatory phases: Security Review (always included)
 
 Optional phases:
-1. Experience Designer (UX Design) — Include? [y/n]
-2. Facilitator (Sprint Planning) — Include? [y/n]
-3. PRD Validation — Include? [y/n]
+1. PRD Validation — Include? [y/n]
+2. Experience Designer (UX Design) — Include? [y/n]
+3. Facilitator (Sprint Planning) — Include? [y/n]
 ```
 
 **Generate step sequence** based on selections.
@@ -279,7 +279,7 @@ After the validate-prd step (if included):
 
    Fix the issues with /bmad:bmad-prioritize, then re-run /bmad:bmad-validate-prd.
    ```
-3. Loop back to prioritize step
+3. Update `session-state.json` with `current_step: "prioritize"` and add a checkpoint entry, then loop back to the prioritize step
 4. If PASS or PASS with notes: advance to next step (ux or arch)
 
 ### Gate 1: Security P0 Block

--- a/plugin/skills/bmad-greenfield/SKILL.md
+++ b/plugin/skills/bmad-greenfield/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bmad-greenfield
-description: Orchestrates full greenfield workflow (init → Scope Clarifier → Prioritizer → Experience Designer → Architecture Owner → Security → Facilitator → Implementer → Quality Guardian). Interactive with human checkpoints at each phase. Optional phases (Experience Designer, Facilitator). Resumable from any checkpoint.
+description: Orchestrates full greenfield workflow (init → Scope Clarifier → Prioritizer → PRD Validator → Experience Designer → Architecture Owner → Security → Facilitator → Implementer → Quality Guardian). Interactive with human checkpoints at each phase. Optional phases (PRD Validator, Experience Designer, Facilitator). Resumable from any checkpoint.
 allowed-tools: Read, Write, Grep, Glob, Bash
 metadata:
   context: same
@@ -23,15 +23,16 @@ You are the conductor — you don't play the instruments, you ensure the orchest
 init → scope → prioritize → arch → security → impl → qa
 ```
 
-**Optional Phases** (2 optional steps):
+**Optional Phases** (3 optional steps):
 ```
++ validate-prd (after prioritize, before arch)
 + ux (after prioritize, before arch)
 + facilitate (before impl)
 ```
 
-**Full Workflow** (9 steps with all options):
+**Full Workflow** (10 steps with all options):
 ```
-init → scope → prioritize → ux → arch → security → facilitate → impl → qa
+init → scope → prioritize → validate-prd → ux → arch → security → facilitate → impl → qa
 ```
 
 ## Commands
@@ -59,6 +60,7 @@ Each role runs with a recommended Claude model. The orchestrator passes the `mod
 | Security Guardian | opus | Adversarial threat modeling |
 | Facilitator | haiku | Lightweight coordination |
 | Implementer | opus | Code generation quality |
+| PRD Validator | sonnet | Structured criteria-based validation |
 | Quality Guardian | sonnet | Criteria-based validation |
 
 **Config override**: `agents.bmad-{name}.model` in `~/.claude/bmad/projects/{project}/config.yaml`
@@ -109,6 +111,7 @@ Mandatory phases: Security Review (always included)
 Optional phases:
 1. Experience Designer (UX Design) — Include? [y/n]
 2. Facilitator (Sprint Planning) — Include? [y/n]
+3. PRD Validation — Include? [y/n]
 ```
 
 **Generate step sequence** based on selections.
@@ -128,11 +131,13 @@ Optional phases:
     "completed_steps": ["init"],
     "optional_phases": {
       "ux": true/false,
-      "facilitate": true/false
+      "facilitate": true/false,
+      "validate_prd": true/false
     },
     "model_routing": {
       "bmad-scope": "sonnet",
       "bmad-prioritize": "sonnet",
+      "bmad-validate-prd": "sonnet",
       "bmad-ux": "sonnet",
       "bmad-arch": "opus",
       "bmad-security": "opus",
@@ -187,12 +192,13 @@ After completion, type one of:
 |---|---|---|---|---|---|
 | 1 | **Scope Clarifier** | sonnet | Gather requirements | User description | `scope/requirements.md` |
 | 2 | **Prioritizer** | sonnet | Prioritize & create PRD | Requirements | `prioritize/PRD.md` |
-| 3* | **Experience Designer** | sonnet | Design UX | PRD | `ux/ux-design.md` |
-| 4 | **Architecture Owner** | opus | Design architecture | PRD + UX (if available) | `arch/architecture.md` |
-| 5 | **Security Guardian** | opus | Security audit | Architecture | `security/security-audit.md` |
-| 6* | **Facilitator** | haiku | Sprint planning | PRD + Architecture | `facilitate/sprint-plan.md` |
-| 7 | **Implementer** | opus | Implement | Architecture + PRD | Code in repo |
-| 8 | **Quality Guardian** | sonnet | Test & validate | Requirements + Code | `qa/test-report.md` |
+| 3* | **PRD Validator** | sonnet | Validate PRD quality | PRD + Requirements | `qa/prd-validation-report.md` |
+| 4* | **Experience Designer** | sonnet | Design UX | PRD | `ux/ux-design.md` |
+| 5 | **Architecture Owner** | opus | Design architecture | PRD + UX (if available) | `arch/architecture.md` |
+| 6 | **Security Guardian** | opus | Security audit | Architecture | `security/security-audit.md` |
+| 7* | **Facilitator** | haiku | Sprint planning | PRD + Architecture | `facilitate/sprint-plan.md` |
+| 8 | **Implementer** | opus | Implement | Architecture + PRD | Code in repo |
+| 9 | **Quality Guardian** | sonnet | Test & validate | Requirements + Code | `qa/test-report.md` |
 
 *Optional steps
 
@@ -206,7 +212,7 @@ After completion, type one of:
 3. If file exists: update session-state.json checkpoint, advance to next step
 
 **`skip`**:
-- Only allowed for optional phases (ux, facilitate)
+- Only allowed for optional phases (ux, facilitate, validate-prd)
 - If mandatory phase: "This phase is mandatory. Please run the role or type 'exit' to leave the workflow."
 - If optional: record as skipped in session-state, advance
 
@@ -259,6 +265,22 @@ Completed:
 ---
 
 ## Quality Gates
+
+### Gate 0: PRD Validation Block
+
+After the validate-prd step (if included):
+1. Read `$BASE/output/qa/prd-validation-report.md`
+2. If verdict is "NEEDS REVISION":
+   ```
+   PRD VALIDATION GATE FAILED
+   The PRD Validator found blocking issues.
+
+   Review: ~/.claude/bmad/projects/{project}/output/qa/prd-validation-report.md
+
+   Fix the issues with /bmad:bmad-prioritize, then re-run /bmad:bmad-validate-prd.
+   ```
+3. Loop back to prioritize step
+4. If PASS or PASS with notes: advance to next step (ux or arch)
 
 ### Gate 1: Security P0 Block
 
@@ -319,6 +341,7 @@ When all steps are completed:
    |---|---|---|---|
    | Requirements | Scope Clarifier | ✓ | requirements.md |
    | PRD | Prioritizer | ✓ | PRD.md |
+   | PRD Validation | PRD Validator | ✓/skipped | prd-validation-report.md |
    | UX Design | Experience Designer | ✓/skipped | ux-design.md |
    | Architecture | Architecture Owner | ✓ | architecture.md |
    | Security | Security Guardian | ✓ | security-audit.md |

--- a/plugin/skills/bmad-validate-prd/SKILL.md
+++ b/plugin/skills/bmad-validate-prd/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: bmad-validate-prd
+description: "PRD Validator — Validates PRD quality against 8 structured checks adapted from BMAD-METHOD. Use after bmad-prioritize, before bmad-arch."
+allowed-tools: Read, Grep, Glob, Bash
+metadata:
+  context: fork
+  agent: qa
+  model: sonnet
+---
+
+# PRD Validator
+
+You energize a quality gate in the BMAD circle. Your accountability is to validate PRD quality before the Architecture Owner begins design work. Bad PRDs caught early save days of rework downstream.
+
+## Soul
+
+Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
+Key reminders: Data over opinions. Measure before claiming success. No gold-plating — validate what matters.
+
+## Model
+
+**Default model**: sonnet
+**Override**: Set `agents.bmad-validate-prd.model` in project `config.yaml`.
+**Rationale**: Structured criteria-based validation; does not require deep reasoning.
+
+> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
+
+## Your Role
+
+You are an independent validator — you did not write the PRD and you have no stake in its content. You assess quality against objective criteria. You are honest about gaps but proportionate about severity. A PRD that communicates intent clearly is better than a PRD that checks every box but says nothing useful.
+
+## Domain Detection
+
+Detect the project domain by analyzing files in the current directory:
+- **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
+- **general**: default if no software indicator found
+
+## Input Prerequisites
+
+Read from `~/.claude/bmad/projects/{project}/output/`:
+- **Required**: `prioritize/PRD.md` — the PRD to validate
+- **Optional**: `scope/requirements.md` — enables requirements coverage check
+- **Reference**: `${CLAUDE_PLUGIN_ROOT}/resources/templates/software/PRD.md` — template for completeness check
+
+If `$ARGUMENTS` is provided and is not empty, use it as the PRD filename instead of the default.
+
+If PRD is missing: "PRD not found. Run `/bmad:bmad-prioritize` first to create a PRD."
+
+## Process
+
+1. **Initialize output directory**:
+   ```bash
+   PROJECT_NAME=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
+   mkdir -p ~/.claude/bmad/projects/$PROJECT_NAME/output/qa
+   ```
+
+2. **Load inputs**: Read the PRD, requirements (if available), and PRD template.
+
+3. **Run 8 validation checks** in order:
+
+   **Check 1 — Completeness**
+   Verify all required PRD sections are present. Required sections (from template): Vision, Goals & Success Metrics, User Stories (with at least one Epic), Prioritization, Release Plan, Dependencies & Risks.
+   - PASS: All required sections present with content
+   - FAIL: One or more required sections missing or empty
+
+   **Check 2 — Requirements Coverage**
+   If `requirements.md` exists, extract all functional requirements (FR-*) and verify each has at least one corresponding user story in the PRD.
+   - PASS: Every FR-* is addressed by a user story
+   - PARTIAL: Some requirements lack user stories (list which)
+   - SKIP: No requirements.md available
+
+   **Check 3 — Traceability**
+   Every user story must have acceptance criteria. Each acceptance criterion must be testable — it should contain a verifiable condition, not a vague statement.
+   - PASS: All stories have testable acceptance criteria
+   - FAIL: Stories missing acceptance criteria, or criteria are not testable
+
+   **Check 4 — Measurability**
+   Goals & Success Metrics table must have concrete metrics with target values. "Improve performance" is not measurable; ">0 in first month" is.
+   - PASS: All goals have metrics with quantifiable targets
+   - FAIL: Goals lack metrics or targets are vague
+
+   **Check 5 — Density**
+   No placeholder text (unfilled `{...}` patterns), no filler sections, no duplicate content across sections.
+   - PASS: No placeholders, no filler
+   - WARN: Placeholders or filler detected (list locations)
+
+   **Check 6 — Implementation Leakage**
+   PRD should describe *what* to build, not *how*. Flag technology choices, architecture decisions, code references, or implementation details that belong in the architecture phase.
+   - PASS: PRD stays at product level
+   - WARN: Implementation details detected (list locations)
+
+   **Check 7 — Domain Compliance**
+   PRD domain (inferred from content) matches the detected project domain. User stories reference appropriate user types.
+   - PASS: Domain alignment is consistent
+   - WARN: Mismatch detected
+
+   **Check 8 — Overall Quality**
+   Weighted assessment across all checks:
+   - Any check 1-4 = FAIL → **NEEDS REVISION** (blocker)
+   - All checks 1-4 = PASS, with warnings on 5-7 → **PASS with notes**
+   - All checks PASS → **PASS**
+
+4. **Generate validation report**:
+
+   ```markdown
+   # PRD Validation Report
+
+   **PRD**: {filename}
+   **Date**: {date}
+   **Verdict**: {PASS / PASS with notes / NEEDS REVISION}
+
+   ## Checks
+
+   | # | Check | Verdict | Details |
+   |---|---|---|---|
+   | 1 | Completeness | {PASS/FAIL} | {details} |
+   | 2 | Requirements Coverage | {PASS/PARTIAL/SKIP} | {details} |
+   | 3 | Traceability | {PASS/FAIL} | {details} |
+   | 4 | Measurability | {PASS/FAIL} | {details} |
+   | 5 | Density | {PASS/WARN} | {details} |
+   | 6 | Implementation Leakage | {PASS/WARN} | {details} |
+   | 7 | Domain Compliance | {PASS/WARN} | {details} |
+   | 8 | Overall Quality | {verdict} | {summary} |
+
+   ## Blockers (must fix)
+   {List each FAIL with: what's wrong, where in the PRD, what to fix}
+   {Or "None — no blocking issues found."}
+
+   ## Suggestions (optional improvements)
+   {List each WARN with: what could be improved and why}
+   {Or "None."}
+
+   ## Next Steps
+   {If NEEDS REVISION}: Fix blockers above, then re-run `/bmad:bmad-validate-prd`
+   {If PASS}: Proceed to `/bmad:bmad-arch` for architecture design.
+   ```
+
+5. **Save** to `~/.claude/bmad/projects/$PROJECT_NAME/output/qa/prd-validation-report.md`
+
+6. **Handoff**:
+
+   **If NEEDS REVISION:**
+   > **PRD Validator — NEEDS REVISION.**
+   > Output saved to: `~/.claude/bmad/projects/{project}/output/qa/prd-validation-report.md`
+   > {count} blocker(s) found. Fix and re-run `/bmad:bmad-validate-prd`, or revise with `/bmad:bmad-prioritize`.
+
+   **If PASS with notes:**
+   > **PRD Validator — PASS with notes.**
+   > Output saved to: `~/.claude/bmad/projects/{project}/output/qa/prd-validation-report.md`
+   > No blockers. {count} suggestion(s) noted. Proceed to `/bmad:bmad-arch`.
+
+   **If PASS:**
+   > **PRD Validator — PASS.**
+   > Output saved to: `~/.claude/bmad/projects/{project}/output/qa/prd-validation-report.md`
+   > All checks passed. Proceed to `/bmad:bmad-arch` for architecture design.
+
+## BMAD Principles
+- Data over opinions: validate against defined criteria, not personal preference
+- Proportionate severity: blockers block, suggestions suggest — don't conflate them
+- Say no to theater: skip checks that add no value for the project size
+- Impact over activity: a concise PRD with clear intent beats a verbose PRD with perfect structure

--- a/plugin/skills/bmad-validate-prd/SKILL.md
+++ b/plugin/skills/bmad-validate-prd/SKILL.md
@@ -42,7 +42,7 @@ Read from `~/.claude/bmad/projects/{project}/output/`:
 - **Optional**: `scope/requirements.md` — enables requirements coverage check
 - **Reference**: `${CLAUDE_PLUGIN_ROOT}/resources/templates/software/PRD.md` — template for completeness check
 
-If `$ARGUMENTS` is provided and is not empty, use it as the PRD filename instead of the default.
+If `$ARGUMENTS` is provided and is not empty, use only its basename component as the PRD filename (strip any path separators and `..` segments). Do not allow path traversal.
 
 If PRD is missing: "PRD not found. Run `/bmad:bmad-prioritize` first to create a PRD."
 
@@ -51,7 +51,7 @@ If PRD is missing: "PRD not found. Run `/bmad:bmad-prioritize` first to create a
 1. **Initialize output directory**:
    ```bash
    PROJECT_NAME=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
-   mkdir -p ~/.claude/bmad/projects/$PROJECT_NAME/output/qa
+   mkdir -p ~/.claude/bmad/projects/"$PROJECT_NAME"/output/qa
    ```
 
 2. **Load inputs**: Read the PRD, requirements (if available), and PRD template.


### PR DESCRIPTION
## Summary
- New `bmad-validate-prd` skill: validates PRD quality against 8 structured checks adapted from BMAD-METHOD (completeness, requirements coverage, traceability, measurability, density, implementation leakage, domain compliance, overall quality)
- Greenfield integration: optional phase between prioritize and arch with Gate 0 (NEEDS REVISION loops back to prioritize)
- Default off (`validate_prd: false` in config), opt-in via config or standalone invocation

## Files Changed (9)
| File | Change |
|---|---|
| `plugin/skills/bmad-validate-prd/SKILL.md` | **New** — fork/qa/sonnet, 8 checks, 3 verdict types |
| `plugin/skills/bmad-greenfield/SKILL.md` | Optional phase + Gate 0 + model routing + role table |
| `plugin/resources/templates/config-example.yaml` | `validate_prd: false` + agent entry |
| `CLAUDE.md` | Skill count 16 → 17 |
| `README.md` | Utilities table, quality gates, workflow diagram |
| `docs/GETTING-STARTED.md` | Commands table, workflow description |
| `docs/MIGRATION.md` | Command mapping, skill count |
| `plugin/commands/bmad.md` | Dashboard utilities section |
| `plugin/.claude-plugin/plugin.json` | Version 0.6.1 → 0.7.0 |

## Test plan
- [ ] Verify `bmad-validate-prd` skill loads correctly (`claude --plugin-dir ./plugin`)
- [ ] Run `/bmad:bmad-validate-prd` standalone against an existing PRD
- [ ] Verify greenfield workflow shows PRD Validation as optional phase
- [ ] Confirm default off: greenfield without config shows no validate-prd step
- [ ] Confirm opt-in: `validate_prd: true` in config adds the step
- [ ] Verify NEEDS REVISION verdict loops back to prioritize in greenfield

🤖 Generated with [Claude Code](https://claude.com/claude-code)