### PR TITLE
feat: self-verification guardrails and phase gate defaults (v0.8.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,9 @@
   "plugins": [
     {
       "name": "bmad",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "source": "./plugin",
-      "description": "17 skills (9 holacracy roles + 8 utilities) with structured workflows, quality gates, TDD enforcement, security audits, and full customization"
+      "description": "17 skills (9 holacracy roles + 8 utilities) with structured workflows, quality gates, self-verification guardrails, TDD enforcement, security audits, and full customization"
     }
   ]
 }

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -55,7 +55,7 @@ agents:
       Follow project coding standards and existing conventions.
 
 # TDD (Test-Driven Development)
-# Enabled by default. The Implementer enforces red-green-refactor via /bmad-tdd.
+# Enabled by default. The Implementer enforces red-green-refactor via /bmad:bmad-tdd.
 # The Quality Guardian verifies TDD compliance in commit history.
 tdd:
   enabled: true           # Set to false to disable TDD workflow

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -171,6 +171,35 @@ mv ~/Documents/BMAD-Setup ~/Documents/BMAD-Setup-archived
 | N/A | `/bmad:bmad-tdd` (TDD enforcement) |
 | N/A | `/bmad:bmad` (status dashboard) |
 
+## What Changes (v0.8.0 — Guardrails Enhancement)
+
+### Self-Verification Protocol
+
+Fork-context roles (bmad-arch, bmad-impl, bmad-qa) now verify their output against upstream artifacts before handoff. Each role appends a **Traceability** section to its output document showing coverage of upstream requirements.
+
+- **Enabled by default** — no action required
+- **Disable per-project**: add `guardrails.self_check: false` to your `config.yaml`
+- **Graceful degradation**: if upstream artifacts don't exist, self-verification is silently skipped
+
+### validate-prd Default Changed
+
+The greenfield workflow now defaults PRD Validation to **enabled** (previously disabled). When starting a new greenfield workflow, PRD Validation will be suggested as default-on.
+
+- **No action required** — you can still opt out during greenfield setup
+- **Existing configs preserved**: if your `config.yaml` has `validate_prd: false`, it takes precedence
+
+### New Config Option
+
+```yaml
+# Add to your config.yaml if you want to disable self-verification
+guardrails:
+  self_check: false
+```
+
+### New Resource File
+
+`plugin/resources/guardrails.md` — defines the self-verification protocol. Roles read this at runtime alongside `soul.md`.
+
 ## Key Improvements After Migration
 
 1. **Real isolation**: Each role runs in its own context — no context pollution between phases

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bmad",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Multi-agent development workflow plugin with holacracy roles, quality gates, and full customization",
   "author": {
     "name": "Alessio Roberto",

--- a/plugin/resources/guardrails.md
+++ b/plugin/resources/guardrails.md
@@ -1,0 +1,41 @@
+# Guardrails
+
+## Self-Verification Protocol
+
+Before handoff, verify your output covers upstream requirements. This closes the feedback loop between roles and catches gaps before they compound downstream.
+
+### When to Run
+- **Default**: enabled for all fork-context roles
+- **Skip if**: project config has `guardrails.self_check: false`
+- **Skip if**: upstream artifact does not exist (graceful degradation — do not block the role)
+
+### Upstream Artifact Mapping
+
+| Your Role | Read This | Check For |
+|---|---|---|
+| bmad-arch | `scope/requirements.md` or `prioritize/PRD.md` | Each FR-*/user story addressed in architecture |
+| bmad-impl | `arch/architecture.md` | Each component/module implemented |
+| bmad-qa | `scope/requirements.md` or `prioritize/PRD.md` | Each acceptance criterion has a test |
+| bmad-prioritize | `scope/requirements.md` | Each FR-* has a user story |
+| bmad-ux | `prioritize/PRD.md` | Each user story has UX coverage |
+| bmad-security | `arch/architecture.md` | Each component has threat analysis |
+
+Read the upstream artifact from `~/.claude/bmad/projects/{project}/output/`. If the first path doesn't exist, try the alternative (e.g., PRD.md if requirements.md is missing).
+
+### Protocol
+
+1. Extract the list of checkable items from the upstream artifact (FR-*, user stories, components, acceptance criteria — depending on your role's "Check For" column above).
+2. For each item, assess coverage in your output:
+   - ✅ **Covered** — explicitly addressed
+   - ⚠️ **Partial** — mentioned but incomplete
+   - ❌ **Missing** — not addressed
+3. Append a `## Traceability` section to your output document:
+
+   | Upstream Item | Status | Notes |
+   |---|---|---|
+   | {item} | ✅/⚠️/❌ | {brief note} |
+
+4. Update your handoff message:
+   - If all ✅: no change needed
+   - If any ⚠️: append `Note: {N} items partially covered. See Traceability section.`
+   - If any ❌: append `⚠️ {N} upstream items not covered. See Traceability section.`

--- a/plugin/resources/templates/config-example.yaml
+++ b/plugin/resources/templates/config-example.yaml
@@ -20,17 +20,17 @@ greenfield_defaults:
   facilitate: false
   validate_prd: true     # PRD quality validation after prioritize (default: true since v0.8.0)
 
-# Test-Driven Development (TDD) enforcement
-# TDD is enabled by default. bmad-impl uses red-green-refactor cycle via bmad-tdd
-# for each implementation unit. bmad-qa verifies TDD compliance by inspecting commit
-# history for test(red): → feat(green): → refactor: pattern.
-# When the workflow doesn't involve testable code, bmad-impl prompts to disable.
 # Guardrails — self-verification before handoff
 # Roles verify their output covers upstream requirements before completing.
 # Adds a Traceability section to output documents.
 guardrails:
   self_check: true        # Enable self-verification (default: true)
 
+# Test-Driven Development (TDD) enforcement
+# TDD is enabled by default. bmad-impl uses red-green-refactor cycle via bmad-tdd
+# for each implementation unit. bmad-qa verifies TDD compliance by inspecting commit
+# history for test(red): → feat(green): → refactor: pattern.
+# When the workflow doesn't involve testable code, bmad-impl prompts to disable.
 tdd:
   enabled: true           # Enable TDD workflow (default: true)
   enforcement: hard       # hard = QA blocks on violation; soft = QA warns only

--- a/plugin/resources/templates/config-example.yaml
+++ b/plugin/resources/templates/config-example.yaml
@@ -26,6 +26,8 @@ greenfield_defaults:
 guardrails:
   self_check: true        # Enable self-verification (default: true)
 
+# ─────────────────────────────────────────────────────────────────
+
 # Test-Driven Development (TDD) enforcement
 # TDD is enabled by default. bmad-impl uses red-green-refactor cycle via bmad-tdd
 # for each implementation unit. bmad-qa verifies TDD compliance by inspecting commit

--- a/plugin/resources/templates/config-example.yaml
+++ b/plugin/resources/templates/config-example.yaml
@@ -18,13 +18,19 @@
 greenfield_defaults:
   ux: true
   facilitate: false
-  validate_prd: false    # PRD quality validation after prioritize
+  validate_prd: true     # PRD quality validation after prioritize (default: true since v0.8.0)
 
 # Test-Driven Development (TDD) enforcement
 # TDD is enabled by default. bmad-impl uses red-green-refactor cycle via bmad-tdd
 # for each implementation unit. bmad-qa verifies TDD compliance by inspecting commit
 # history for test(red): → feat(green): → refactor: pattern.
 # When the workflow doesn't involve testable code, bmad-impl prompts to disable.
+# Guardrails — self-verification before handoff
+# Roles verify their output covers upstream requirements before completing.
+# Adds a Traceability section to output documents.
+guardrails:
+  self_check: true        # Enable self-verification (default: true)
+
 tdd:
   enabled: true           # Enable TDD workflow (default: true)
   enforcement: hard       # hard = QA blocks on violation; soft = QA warns only

--- a/plugin/skills/bmad-arch/SKILL.md
+++ b/plugin/skills/bmad-arch/SKILL.md
@@ -40,7 +40,7 @@ Detect the project domain by analyzing files in the current directory:
 Read requirements from `~/.claude/bmad/projects/{project}/output/`:
 - Check for: `scope/requirements.md`
 - Also check: `prioritize/PRD.md` (if Prioritizer has refined requirements)
-- If none found: "Requirements missing. Run `/bmad-scope` first to gather requirements."
+- If none found: "Requirements missing. Run `/bmad:bmad-scope` first to gather requirements."
 
 Also check for project config: `~/.claude/bmad/projects/{project}/config.yaml`
 - If `extra_instructions` for bmad-arch exists, incorporate them

--- a/plugin/skills/bmad-arch/SKILL.md
+++ b/plugin/skills/bmad-arch/SKILL.md
@@ -45,6 +45,7 @@ Read requirements from `~/.claude/bmad/projects/{project}/output/`:
 Also check for project config: `~/.claude/bmad/projects/{project}/config.yaml`
 - If `extra_instructions` for bmad-arch exists, incorporate them
 - If `context_files` defined, read those files for additional architectural context
+- **Upstream for self-verification**: `scope/requirements.md` or `prioritize/PRD.md` (loaded before handoff if guardrails enabled)
 
 ## Domain-Specific Behavior
 
@@ -103,12 +104,14 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
 
 6. **Generate architecture document**: Write to `~/.claude/bmad/projects/$PROJECT_NAME/output/arch/{filename}`
 
-7. **MCP Integration** (if available):
+7. **Self-Verification**: Read and follow the self-verification protocol in `${CLAUDE_PLUGIN_ROOT}/resources/guardrails.md`. Upstream artifact: `scope/requirements.md` or `prioritize/PRD.md`.
+
+8. **MCP Integration** (if available):
    - **Domain-specific tools**: If domain-specific MCP tools are available (configured via deps-manifest.yaml), use them to look up framework documentation and platform best practices.
    - **Linear**: Reference project context and link architecture decisions to issues
    - **claude-mem**: Search for past architectural decisions in similar projects. Save key ADRs at completion.
 
-8. **Handoff**:
+9. **Handoff**:
    > **Architecture Owner — Complete.**
    > Output saved to: `~/.claude/bmad/projects/{project}/output/arch/{filename}`
    > ADRs documented: {count}

--- a/plugin/skills/bmad-facilitate/SKILL.md
+++ b/plugin/skills/bmad-facilitate/SKILL.md
@@ -41,7 +41,7 @@ Read from `~/.claude/bmad/projects/{project}/output/`:
 - PRD: `prioritize/PRD-*.md`
 - Architecture: `arch/architecture.md`
 - Optional: `qa/test-plan-*.md`
-- If PRD missing: "PRD needed for sprint planning. Run `/bmad-prioritize` first."
+- If PRD missing: "PRD needed for sprint planning. Run `/bmad:bmad-prioritize` first."
 
 ## Process
 

--- a/plugin/skills/bmad-greenfield/SKILL.md
+++ b/plugin/skills/bmad-greenfield/SKILL.md
@@ -109,9 +109,9 @@ Domain: {detected domain}
 Mandatory phases: Security Review (always included)
 
 Optional phases:
-1. PRD Validation — Include? [y/n]
-2. Experience Designer (UX Design) — Include? [y/n]
-3. Facilitator (Sprint Planning) — Include? [y/n]
+1. Experience Designer (UX Design) — Include? [y/n]
+2. Facilitator (Sprint Planning) — Include? [y/n]
+3. PRD Validation — Include? [Y/n]
 ```
 
 **Generate step sequence** based on selections.

--- a/plugin/skills/bmad-impl/SKILL.md
+++ b/plugin/skills/bmad-impl/SKILL.md
@@ -40,7 +40,7 @@ Detect the project domain by analyzing files in the current directory:
 Read design from `~/.claude/bmad/projects/{project}/output/`:
 - Check for: `arch/architecture.md`
 - Also useful: `scope/requirements.md`, `prioritize/PRD.md`
-- If architecture missing: "Design missing. Run `/bmad-arch` first."
+- If architecture missing: "Design missing. Run `/bmad:bmad-arch` first."
 
 Also check for project config: `~/.claude/bmad/projects/{project}/config.yaml`
 - If `context_files` defined, read those for additional context

--- a/plugin/skills/bmad-impl/SKILL.md
+++ b/plugin/skills/bmad-impl/SKILL.md
@@ -45,6 +45,7 @@ Read design from `~/.claude/bmad/projects/{project}/output/`:
 Also check for project config: `~/.claude/bmad/projects/{project}/config.yaml`
 - If `context_files` defined, read those for additional context
 - If `extra_instructions` for bmad-impl exists, incorporate them
+- **Upstream for self-verification**: `arch/architecture.md` (loaded before handoff if guardrails enabled)
 
 ## Progressive Disclosure (Context Sharding)
 
@@ -109,14 +110,16 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
 
 7. **CLAUDE.md compliance**: If a `CLAUDE.md` exists in the repo root, verify your implementation follows its standards before handoff.
 
-8. **Save implementation notes** to: `~/.claude/bmad/projects/$PROJECT_NAME/output/impl/implementation-notes-{date}.md`
+8. **Self-Verification**: Read and follow the self-verification protocol in `${CLAUDE_PLUGIN_ROOT}/resources/guardrails.md`. Upstream artifact: `arch/architecture.md`.
 
-9. **MCP Integration** (if available):
-   - **Domain-specific tools**: If domain-specific MCP tools are available (configured via deps-manifest.yaml), use them to look up framework documentation and platform best practices.
-   - **Linear**: Update issue status, comment on implementation progress
-   - **claude-mem**: Search for past implementation patterns. Save key decisions at completion.
+9. **Save implementation notes** to: `~/.claude/bmad/projects/$PROJECT_NAME/output/impl/implementation-notes-{date}.md`
 
-10. **Handoff**:
+10. **MCP Integration** (if available):
+    - **Domain-specific tools**: If domain-specific MCP tools are available (configured via deps-manifest.yaml), use them to look up framework documentation and platform best practices.
+    - **Linear**: Update issue status, comment on implementation progress
+    - **claude-mem**: Search for past implementation patterns. Save key decisions at completion.
+
+11. **Handoff**:
    > **Implementer — Complete.**
    > Output saved to: `~/.claude/bmad/projects/{project}/output/impl/`
    > Next suggested role: `/bmad:bmad-qa` for testing and validation.

--- a/plugin/skills/bmad-init/SKILL.md
+++ b/plugin/skills/bmad-init/SKILL.md
@@ -180,28 +180,29 @@ Dependencies:
   Update all:      bash <plugin-root>/resources/scripts/update-deps.sh
 
 Available roles:
-  /bmad-scope       - Scope Clarifier (requirements, user stories)
-  /bmad-arch        - Architecture Owner (design, ADRs, trade-offs)
-  /bmad-impl        - Implementer (implementation, code review)
-  /bmad-qa          - Quality Guardian (test strategy, QA)
-  /bmad-ux          - Experience Designer (UI/UX design)
-  /bmad-prioritize  - Prioritizer (prioritization, roadmap)
-  /bmad-facilitate  - Facilitator (sprint planning, coordination)
-  /bmad-security    - Security Guardian (audits, threat modeling)
-  /bmad-docs        - Documentation Steward (doc generation)
+  /bmad:bmad-scope       - Scope Clarifier (requirements, user stories)
+  /bmad:bmad-arch        - Architecture Owner (design, ADRs, trade-offs)
+  /bmad:bmad-impl        - Implementer (implementation, code review)
+  /bmad:bmad-qa          - Quality Guardian (test strategy, QA)
+  /bmad:bmad-ux          - Experience Designer (UI/UX design)
+  /bmad:bmad-prioritize  - Prioritizer (prioritization, roadmap)
+  /bmad:bmad-facilitate  - Facilitator (sprint planning, coordination)
+  /bmad:bmad-security    - Security Guardian (audits, threat modeling)
+  /bmad:bmad-docs        - Documentation Steward (doc generation)
 
 Review:
-  /bmad-code-review - Multi-agent PR code review with CLAUDE.md compliance
-  /bmad-triage      - Triage PR review comments
+  /bmad:bmad-code-review - Multi-agent PR code review with CLAUDE.md compliance
+  /bmad:bmad-triage      - Triage PR review comments
 
 Orchestrators:
-  /bmad-greenfield - Full workflow (analysis → QA)
-  /bmad-sprint     - Sprint planning ceremony
+  /bmad:bmad-greenfield - Full workflow (analysis → QA)
+  /bmad:bmad-sprint     - Sprint planning ceremony
 
 Utilities:
-  /bmad-tdd        - TDD red-green-refactor cycle
-  /bmad-shard      - Split large documents into shards
-  /bmad-init       - Project initialization (already done)
+  /bmad:bmad-validate-prd - Validate PRD quality (8 checks)
+  /bmad:bmad-tdd          - TDD red-green-refactor cycle
+  /bmad:bmad-shard        - Split large documents into shards
+  /bmad:bmad-init         - Project initialization (already done)
 
-Start with: /bmad-scope to gather requirements, or /bmad-greenfield for the full workflow.
+Start with: /bmad:bmad-scope to gather requirements, or /bmad:bmad-greenfield for the full workflow.
 ```

--- a/plugin/skills/bmad-prioritize/SKILL.md
+++ b/plugin/skills/bmad-prioritize/SKILL.md
@@ -39,7 +39,7 @@ Detect the project domain by analyzing files in the current directory:
 
 Read from `~/.claude/bmad/projects/{project}/output/`:
 - Requirements: `scope/requirements.md`
-- If requirements missing: "Requirements needed. Run `/bmad-scope` first to gather requirements."
+- If requirements missing: "Requirements needed. Run `/bmad:bmad-scope` first to gather requirements."
 
 ## Process
 

--- a/plugin/skills/bmad-qa/SKILL.md
+++ b/plugin/skills/bmad-qa/SKILL.md
@@ -41,7 +41,7 @@ Read from `~/.claude/bmad/projects/{project}/output/`:
 - Requirements: `scope/requirements.md` or `prioritize/PRD.md`
 - Architecture: `arch/architecture.md`
 - Implementation notes: `impl/implementation-notes-*.md`
-- If requirements missing: "Requirements needed for test planning. Run `/bmad-scope` first."
+- If requirements missing: "Requirements needed for test planning. Run `/bmad:bmad-scope` first."
 - **Upstream for self-verification**: `scope/requirements.md` or `prioritize/PRD.md` (loaded before handoff if guardrails enabled)
 
 ## Domain-Specific Behavior

--- a/plugin/skills/bmad-qa/SKILL.md
+++ b/plugin/skills/bmad-qa/SKILL.md
@@ -42,6 +42,7 @@ Read from `~/.claude/bmad/projects/{project}/output/`:
 - Architecture: `arch/architecture.md`
 - Implementation notes: `impl/implementation-notes-*.md`
 - If requirements missing: "Requirements needed for test planning. Run `/bmad-scope` first."
+- **Upstream for self-verification**: `scope/requirements.md` or `prioritize/PRD.md` (loaded before handoff if guardrails enabled)
 
 ## Domain-Specific Behavior
 
@@ -287,13 +288,15 @@ Run when invoked with `/bmad:bmad-qa lint`. Validates internal consistency of th
       - `tdd.enforcement: hard` (default) + any FAIL → verdict = **REJECT** (P0: TDD cycle violated)
       - `tdd.enforcement: soft` + any FAIL → add P1 warning, do not override existing verdict
 
-6. **Save** to `~/.claude/bmad/projects/$PROJECT_NAME/output/qa/test-report-{date}.md`
+6. **Self-Verification**: Read and follow the self-verification protocol in `${CLAUDE_PLUGIN_ROOT}/resources/guardrails.md`. Upstream artifact: `scope/requirements.md` or `prioritize/PRD.md`.
 
-7. **MCP Integration** (if available):
+7. **Save** to `~/.claude/bmad/projects/$PROJECT_NAME/output/qa/test-report-{date}.md`
+
+8. **MCP Integration** (if available):
    - **Linear**: Link test results to issues, comment on verification outcomes
    - **claude-mem**: Search for past test patterns. Save test strategy decisions at completion.
 
-8. **Handoff**:
+9. **Handoff**:
    > **Quality Guardian — Complete.**
    > Verdict: **{PASS/CONDITIONAL PASS/REJECT}**
    > Output saved to: `~/.claude/bmad/projects/{project}/output/qa/`

--- a/plugin/skills/bmad-security/SKILL.md
+++ b/plugin/skills/bmad-security/SKILL.md
@@ -40,7 +40,7 @@ Detect the project domain by analyzing files in the current directory:
 Read from `~/.claude/bmad/projects/{project}/output/`:
 - Architecture: `arch/architecture.md`
 - Also useful: `scope/requirements.md`, `prioritize/PRD.md`
-- If architecture missing: "Architecture missing. Run `/bmad-arch` first."
+- If architecture missing: "Architecture missing. Run `/bmad:bmad-arch` first."
 
 Also check for project config: `~/.claude/bmad/projects/{project}/config.yaml`
 - If `extra_instructions` for bmad-security exists, incorporate them

--- a/plugin/skills/bmad-ux/SKILL.md
+++ b/plugin/skills/bmad-ux/SKILL.md
@@ -39,7 +39,7 @@ Detect the project domain by analyzing files in the current directory:
 
 Read from `~/.claude/bmad/projects/{project}/output/`:
 - Requirements: `scope/requirements.md` or `prioritize/PRD.md`
-- If requirements missing: "Requirements needed for UX design. Run `/bmad-scope` first."
+- If requirements missing: "Requirements needed for UX design. Run `/bmad:bmad-scope` first."
 
 ## Domain-Specific Behavior
 


### PR DESCRIPTION
## Summary
- Add centralized self-verification protocol (`guardrails.md`) — roles verify output against upstream artifacts before handoff, appending a Traceability section
- Strengthen greenfield phase gates: PRD validation now defaults to enabled (`[Y/n]`)
- New `guardrails.self_check` config option (default: true, disableable per-project)
- Version bump 0.7.0 → 0.8.0

## Changes
| File | Change |
|---|---|
| `plugin/resources/guardrails.md` | **NEW** — self-verification protocol (~220 tokens) |
| `plugin/skills/bmad-arch/SKILL.md` | +upstream prerequisite, +self-verification step |
| `plugin/skills/bmad-impl/SKILL.md` | +upstream prerequisite, +self-verification step |
| `plugin/skills/bmad-qa/SKILL.md` | +upstream prerequisite, +self-verification step |
| `plugin/skills/bmad-greenfield/SKILL.md` | PRD validation `[y/n]` → `[Y/n]` |
| `plugin/resources/templates/config-example.yaml` | +guardrails section, validate_prd: true |
| `docs/MIGRATION.md` | +v0.8.0 migration section |
| `plugin/.claude-plugin/plugin.json` | 0.7.0 → 0.8.0 |
| `.claude-plugin/marketplace.json` | 0.6.1 → 0.8.0 (fix stale + updated description) |

## Design decisions
- **Centralized resource** (ADR-001): guardrails.md avoids duplicating protocol across 6+ SKILL.md files
- **Graceful degradation**: missing upstream artifacts → skip silently
- **Security gate verified** (ADR-004): already structurally enforced, no change needed
- Token overhead: ~320-520 per invocation (within 1000 token budget)

## Test plan
- [x] All 10 QA acceptance criteria verified (PASS)
- [x] CLAUDE.md compliance checked
- [x] Gate integrity verified (arch → security → impl chain intact)
- [x] Version alignment confirmed (plugin.json = marketplace.json = 0.8.0)
- [ ] Run `/bmad:bmad-qa lint` for full plugin consistency
- [ ] After merge: sync Luscii/claude-marketplace with v0.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)