### PR TITLE
feat: Project Knowledge Packs (v0.10.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,53 @@ bash plugin/resources/scripts/update-deps.sh
 
 The dependency manifest is at `plugin/resources/deps-manifest.yaml`. Per-project overrides go in `config.yaml` under the `dependencies:` key.
 
+## Project Knowledge Packs
+
+**Make BMAD understand your project.** A Knowledge Pack is a set of focused Markdown files in your repo that give every BMAD role deep awareness of your project — its architecture, domain vocabulary, build system, and integrations. CLAUDE.md handles coding standards; the Knowledge Pack handles everything else.
+
+```
+your-repo/
+└── docs/bmad/           # or Docs/bmad/
+    ├── project.md       # Product identity, team, multi-region context
+    ├── domain.md        # Domain vocabulary, data models, terminology glossary
+    ├── architecture.md  # Layers, DI patterns, navigation, migration boundaries
+    ├── build.md         # Build commands, CI pipelines, release process
+    ├── integrations.md  # SDKs, APIs, analytics, auth, feature flags
+    └── config.yaml      # Template — bmad-init copies to ~/.claude/bmad/projects/
+```
+
+### How it works
+
+1. **Knowledge files live in your repo** — committed, versioned, available to the whole team
+2. **`config.yaml` maps files to roles** — each role loads only the slices relevant to its accountability
+3. **`/bmad:bmad-init` auto-detects the config template** and copies it to `~/.claude/bmad/projects/<project>/`
+
+A new team member clones the repo, runs `/bmad:bmad-init`, and BMAD immediately knows the project. No manual setup.
+
+### Role-aware injection
+
+Not every role needs every file. The config maps knowledge by concern:
+
+| Role | Loads |
+|---|---|
+| Scope Clarifier, Prioritizer | project + domain |
+| Architecture Owner | project + domain + architecture + integrations |
+| Implementer | project + domain + architecture + build + integrations |
+| Quality Guardian | project + domain + architecture + build |
+| Code Review | project + architecture + build |
+| Security Guardian | project + architecture + integrations |
+
+### Getting started
+
+1. Create `docs/bmad/` in your repo with the 5 knowledge files
+2. Add a `config.yaml` template with `agents.<role>.context_files` mappings
+3. Run `/bmad:bmad-init` — it detects and activates the config
+4. Every BMAD role now produces project-aware output
+
+See [docs/CUSTOMIZATION.md](docs/CUSTOMIZATION.md) for the full Knowledge Pack configuration guide.
+
+---
+
 ## Architecture
 
 ### Zero Footprint

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.10.0 — Project Knowledge Packs
+
+### Knowledge Packs
+
+BMAD roles can now understand your project deeply — not just coding standards (CLAUDE.md), but domain vocabulary, architecture patterns, build pipelines, and integrations. Create a set of Markdown files in `docs/bmad/` in your repo, and every role loads the relevant slices automatically.
+
+- **5 knowledge files**: `project.md`, `domain.md`, `architecture.md`, `build.md`, `integrations.md`
+- **Role-aware injection**: each role loads only what it needs via `config.yaml` `context_files` mapping
+- **Team distribution**: config template lives in the repo; `bmad-init` auto-detects and copies it
+- **Complement, don't duplicate**: Knowledge Pack owns domain/architecture/build/integrations; CLAUDE.md owns coding standards
+
+### bmad-init Config Template Detection
+
+`/bmad:bmad-init` now searches for a config template at `docs/bmad/config.yaml` (or `Docs/bmad/`, `.bmad/`) in the repo. If found, it copies it to `~/.claude/bmad/projects/<project>/config.yaml` automatically. New team members: clone → `/bmad:bmad-init` → project-aware BMAD.
+
+See [Customization Guide — Section 1](CUSTOMIZATION.md) for the full Knowledge Pack setup guide.
+
 ## v0.9.0 — Anti-Overcomplication & Coherence
 
 ### Simplicity Assessment (bmad-impl)

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -8,16 +8,18 @@ If you just want to tweak how BMAD works for your project, here are the most com
 
 | What you want to do | How |
 |---|---|
-| Give a role extra instructions for your project | Create a config file (see Section 1 below) |
+| **Make BMAD understand your project** | **Create a Knowledge Pack (see Section 1 below)** |
+| Give a role extra instructions for your project | Create a config file (see Section 2 below) |
 | Change the team's working principles | Edit `plugin/resources/soul.md` — plain text, takes effect immediately |
 | Add a document template for the Documentation Steward | Drop a `.md` file in `plugin/resources/templates/docs/` |
-| Add a new role to the circle | Create a folder and skill file (see Section 2 below) |
+| Add a new role to the circle | Create a folder and skill file (see Section 3 below) |
 
 ## Customization Layers
 
 | Layer | What | Where | Friction |
 |---|---|---|---|
 | **Soul** | Team principles | `plugin/resources/soul.md` | Edit file, instant effect |
+| **Knowledge Pack** | Project-aware roles | `docs/bmad/` in your repo | Create Markdown files |
 | **Per-project config** | Role overrides, templates | `~/.claude/bmad/projects/<project>/config.yaml` | Create YAML file |
 | **Role behavior** | Role definitions | `plugin/skills/bmad-<name>/SKILL.md` | Edit SKILL.md |
 | **Templates** | Document templates | `plugin/resources/templates/` | Drop .md file |
@@ -26,9 +28,118 @@ If you just want to tweak how BMAD works for your project, here are the most com
 
 ---
 
-## 1. Per-Project Configuration
+## 1. Project Knowledge Packs
 
-This is a settings file that tells BMAD roles how to behave differently for a specific project. Copy the example and change the values to match your project.
+A Knowledge Pack makes BMAD understand your project. It's a set of Markdown files committed to your repo that every BMAD role can access. CLAUDE.md handles coding standards; the Knowledge Pack handles everything else — domain, architecture, build, integrations.
+
+### Step 1: Create knowledge files
+
+Create `docs/bmad/` (or `Docs/bmad/`) in your repo with these files:
+
+| File | What to include | Target size |
+|---|---|---|
+| `project.md` | Product name, team, stakeholders, multi-region context, business rules | ~80 lines |
+| `domain.md` | Domain vocabulary, data types, terminology glossary, canonical names | ~120 lines |
+| `architecture.md` | Layer diagram, DI patterns, navigation, state management, migration boundaries | ~150 lines |
+| `build.md` | Build commands, CI pipelines, test commands, release process, environments | ~80 lines |
+| `integrations.md` | SDKs, health platforms, analytics, auth, feature flags, project management | ~100 lines |
+
+Each file starts with a metadata comment for staleness tracking:
+
+```markdown
+<!-- bmad-knowledge | last-reviewed: 2026-03-04 | owner: @yourhandle -->
+# Your Title
+
+Content organized with ## headers...
+```
+
+For cross-platform projects sharing domain vocabulary, add a sync marker:
+
+```markdown
+<!-- shared-origin: my-domain | sync-with: other-repo/docs/bmad/domain.md -->
+```
+
+### Step 2: Create config template
+
+Add `docs/bmad/config.yaml` to your repo. This maps knowledge files to BMAD roles:
+
+```yaml
+project:
+  name: my-project
+  domain: software
+
+reading_order:
+  - CLAUDE.md
+  - soul.md
+
+agents:
+  bmad-scope:
+    context_files:
+      - docs/bmad/project.md
+      - docs/bmad/domain.md
+
+  bmad-arch:
+    context_files:
+      - docs/bmad/project.md
+      - docs/bmad/domain.md
+      - docs/bmad/architecture.md
+      - docs/bmad/integrations.md
+    extra_instructions: |
+      Use domain-specific skills for architecture decisions.
+
+  bmad-impl:
+    context_files:
+      - docs/bmad/project.md
+      - docs/bmad/domain.md
+      - docs/bmad/architecture.md
+      - docs/bmad/build.md
+      - docs/bmad/integrations.md
+    extra_instructions: |
+      Run build verification before committing.
+
+  bmad-qa:
+    context_files:
+      - docs/bmad/project.md
+      - docs/bmad/domain.md
+      - docs/bmad/architecture.md
+      - docs/bmad/build.md
+
+  bmad-code-review:
+    context_files:
+      - docs/bmad/project.md
+      - docs/bmad/architecture.md
+      - docs/bmad/build.md
+
+  bmad-ux:
+    context_files:
+      - docs/bmad/project.md
+      - docs/bmad/domain.md
+
+  bmad-security:
+    context_files:
+      - docs/bmad/project.md
+      - docs/bmad/architecture.md
+      - docs/bmad/integrations.md
+```
+
+### Step 3: Activate
+
+Run `/bmad:bmad-init`. It detects the config template at `docs/bmad/config.yaml` and copies it to `~/.claude/bmad/projects/<project>/config.yaml`. Every BMAD role now loads project knowledge automatically.
+
+New team members: clone the repo → `/bmad:bmad-init` → done.
+
+### Design principles
+
+- **Complement, don't duplicate**: CLAUDE.md owns coding standards. Knowledge Pack owns domain, architecture, build, integrations. Never overlap.
+- **Shard by concern, not by role**: 5 files by topic. Roles compose what they need via config. One vocabulary change propagates to all roles.
+- **Budget tokens**: Keep each file under 500 lines (~2000 tokens). The heaviest role (Implementer) loads ~5000 tokens of knowledge pack — about 2.5% of the context window.
+- **Dual purpose**: Knowledge files serve as both AI context and human-readable project documentation.
+
+---
+
+## 2. Per-Project Configuration
+
+This is a settings file that tells BMAD roles how to behave differently for a specific project. You can create it manually or use a Knowledge Pack config template (see above).
 
 Create `~/.claude/bmad/projects/<project-name>/config.yaml`:
 
@@ -66,7 +177,7 @@ See `plugin/resources/templates/config-example.yaml` for a full example with all
 
 ---
 
-## 2. Adding a New Role
+## 3. Adding a New Role
 
 1. Create the directory: `plugin/skills/bmad-<name>/`
 2. Create `SKILL.md` with this template:
@@ -112,7 +223,7 @@ Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 
 ---
 
-## 3. Adding a New Template
+## 4. Adding a New Template
 
 1. Drop a `.md` file in the appropriate directory:
    - `plugin/resources/templates/docs/` — for the Documentation Steward
@@ -124,7 +235,7 @@ Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
 
 ---
 
-## 4. Modifying the Soul
+## 5. Modifying the Soul
 
 Edit `plugin/resources/soul.md`. Changes take effect on the next skill invocation.
 
@@ -132,7 +243,7 @@ The Soul is loaded by every role and sets the behavioral foundation. It includes
 
 ---
 
-## 5. Adding to the Greenfield Workflow
+## 6. Adding to the Greenfield Workflow
 
 To add a new role to the greenfield orchestrator:
 
@@ -143,7 +254,7 @@ To add a new role to the greenfield orchestrator:
 
 ---
 
-## 6. Model Routing
+## 7. Model Routing
 
 BMAD assigns a default Claude model to each fork-context role based on task complexity. Opus handles deep reasoning (architecture, security, implementation), Sonnet handles structured work (scope, prioritization, QA), and Haiku handles lightweight coordination.
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -137,6 +137,7 @@ Each role saves their work in their own subfolder (e.g., `scope/`, `arch/`, `imp
 
 - **You can invoke any role at any time.** There's no strict order — use whoever makes sense for what you need right now.
 - **Roles access context within a session.** If the Scope Clarifier creates requirements, the Prioritizer can read them when you invoke it to create a product plan.
+- **Make BMAD know your project.** Create a Knowledge Pack — a set of Markdown files in `docs/bmad/` that describe your project's domain, architecture, build system, and integrations. Every role automatically loads the relevant files. See the [Customization Guide](CUSTOMIZATION.md) for details.
 - **You can customize how roles behave** per project. See the [Customization Guide](CUSTOMIZATION.md) for details.
 - **All dependencies are optional.** BMAD works out of the box. Extra integrations (like Linear for issue tracking) add functionality but aren't required.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bmad",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Multi-agent development workflow plugin with holacracy roles, quality gates, and full customization",
   "author": {
     "name": "Alessio Roberto",

--- a/plugin/skills/bmad-init/SKILL.md
+++ b/plugin/skills/bmad-init/SKILL.md
@@ -165,7 +165,13 @@ Write to `~/.claude/bmad/projects/$PROJECT_NAME/output/session-state.json`:
 ### 5. Check for project config
 
 - If `~/.claude/bmad/projects/$PROJECT_NAME/config.yaml` exists, report it
-- If not, suggest: "Create `~/.claude/bmad/projects/$PROJECT_NAME/config.yaml` for project-specific customization."
+- If not, search for a config template in the repo:
+  - Check: `docs/bmad/config.yaml`, `Docs/bmad/config.yaml`, `.bmad/config.yaml`
+  - If found: copy it to `~/.claude/bmad/projects/$PROJECT_NAME/config.yaml` and report:
+    ```
+    Found project BMAD config template at <path>. Copied to ~/.claude/bmad/projects/<project>/config.yaml
+    ```
+  - If not found: suggest: "Create `~/.claude/bmad/projects/$PROJECT_NAME/config.yaml` for project-specific customization."
 
 ### 6. Confirm
 


### PR DESCRIPTION
## Summary
- **bmad-init config template detection**: `bmad-init` now searches for `docs/bmad/config.yaml` (or `Docs/bmad/`, `.bmad/`) in the repo and auto-copies it to `~/.claude/bmad/projects/<project>/config.yaml`. New team members: clone → `/bmad:bmad-init` → project-aware BMAD.
- **Knowledge Pack documentation**: Prominently documented across README (new section with file structure + role-aware injection table), CUSTOMIZATION (full 3-step setup guide as new Section 1), GETTING-STARTED (tip), and CHANGELOG (v0.10.0 entry).
- **Version bump**: 0.9.0 → 0.10.0

## Test plan
- [ ] Run `/bmad:bmad-init` in a repo with `docs/bmad/config.yaml` — verify it detects and copies the template
- [ ] Run `/bmad:bmad-init` in a repo without config template — verify it suggests manual creation
- [ ] Run `/bmad:bmad-init` in a repo with existing `~/.claude/bmad/projects/<project>/config.yaml` — verify it reports existing config
- [ ] Verify documentation renders correctly on GitHub (README, CUSTOMIZATION, GETTING-STARTED, CHANGELOG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)