### PR TITLE
feat: work tracking via claude-mem for assessment

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,9 @@
   "plugins": [
     {
       "name": "circle",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "source": "./plugin",
-      "description": "17 skills (9 holacracy roles + 8 utilities) with structured workflows, quality gates, self-verification guardrails, anti-overcomplication checks, TDD enforcement, security audits, and full customization"
+      "description": "18 skills (9 holacracy roles + 9 utilities) with structured workflows, quality gates, self-verification guardrails, anti-overcomplication checks, TDD enforcement, security audits, work tracking, and full customization"
     }
   ]
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.1.0 — Work Tracking
+
+### Assessment-Aware Work Tracking
+
+All Circle skills now produce enriched Work Summary blocks at handoff, automatically captured by claude-mem's session hooks. Designed to feed `/assessment-daily` in luscii-matrix with rich observations for the Expert/Core & Master self-assessment framework.
+
+- **New skill: `/circle:track`** — Interactive 3-question capture for work outside Circle skills (debugging, mentoring, cross-team collaboration)
+- **New resource: `work-summary-template.md`** — Structured template with 6 fields aligned to assessment dimensions (Mastery, Autonomy, Impact, Ownership)
+- **12 skills enriched** — arch, impl, qa, scope, prioritize, security, ux, docs, code-review, cycle, facilitate, triage now output Work Summary blocks before handoff
+- Graceful degradation: template missing → skip silently; claude-mem unavailable → text still visible in session
+
 ## v1.0.0 — Circle
 
 ### BMAD → Circle

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "circle",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Holacracy-based development workflow with distributed roles, quality gates, and Shape Up planning",
   "author": {
     "name": "Alessio Roberto",

--- a/plugin/commands/circle.md
+++ b/plugin/commands/circle.md
@@ -55,6 +55,7 @@ Review:
 Utilities:
   /circle:validate-prd — PRD quality validation (8 checks)
   /circle:tdd          — TDD red-green-refactor enforcer
+  /circle:track        — Capture work for assessment tracking
   /circle:init         — Set up Circle for this project
   /circle:shard        — Split large docs for faster processing
 

--- a/plugin/resources/work-summary-template.md
+++ b/plugin/resources/work-summary-template.md
@@ -1,0 +1,22 @@
+# Work Summary Template
+
+Output this block at the end of every skill session, just before the handoff message. Fill each field with specifics from this session's work.
+
+```
+### Work Summary
+- **Role**: {skill name} | **Project**: {project name}
+- **Deliverable**: {what was produced — files, documents, decisions, reviews}
+- **Key decisions**: {choices made and why — alternatives considered, trade-offs evaluated}
+- **Approach**: {how the problem was tackled — methodology, analysis performed, tools used}
+- **Outcome**: {concrete result — counts, metrics, status changes, quality achieved}
+- **Initiative**: {what was self-directed — risks identified proactively, complexity navigated, blockers resolved}
+```
+
+## Guidance
+
+- Be specific: "Designed 3 ADRs covering data model, API contracts, and caching strategy" not "Designed architecture"
+- Include numbers: file counts, issue counts, test results, coverage changes
+- Name the project and files touched — assessment matching needs this context
+- Describe decisions in terms of what was chosen AND what was rejected
+- For initiative: highlight where you went beyond the literal request — identified risks, simplified an over-engineered approach, connected dots across requirements
+- Keep each field to 1-2 sentences — dense and factual, not narrative

--- a/plugin/skills/arch/SKILL.md
+++ b/plugin/skills/arch/SKILL.md
@@ -109,9 +109,11 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
 8. **MCP Integration** (if available):
    - **Domain-specific tools**: If domain-specific MCP tools are available (configured via deps-manifest.yaml), use them to look up framework documentation and platform best practices.
    - **Linear**: Reference project context and link architecture decisions to issues
-   - **claude-mem**: Search for past architectural decisions in similar projects. Save key ADRs at completion.
+   - **claude-mem**: Search for past architectural decisions in similar projects.
 
-9. **Handoff**:
+9. **Work Summary**: Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
+
+10. **Handoff**:
    > **Architecture Owner — Complete.**
    > Output saved to: `~/.claude/circle/projects/{project}/output/arch/{filename}`
    > ADRs documented: {count}

--- a/plugin/skills/code-review/SKILL.md
+++ b/plugin/skills/code-review/SKILL.md
@@ -112,7 +112,9 @@ Save summary to `~/.claude/circle/projects/$PROJECT_NAME/output/code-review/pr-{
 
 **MCP Integration** (if available):
 - **Linear**: Comment review summary on linked issues
-- **claude-mem**: Save review patterns for future reference
+- **claude-mem**: Search for past review patterns.
+
+**Work Summary**: Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
 
 > **Code Review — Complete.**
 > PR #{number} reviewed. {N} issues found (threshold: 80/100).

--- a/plugin/skills/cycle/SKILL.md
+++ b/plugin/skills/cycle/SKILL.md
@@ -223,7 +223,11 @@ At any step:
 ## MCP Integration (if available)
 
 - **Linear**: "Want me to help create a Linear cycle with these bets?" (interactive, never automatic)
-- **claude-mem**: Search past cycle plans. Save cycle commitment at completion.
+- **claude-mem**: Search past cycle plans.
+
+## Work Summary
+
+Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
 
 ## Circle Principles
 

--- a/plugin/skills/docs/SKILL.md
+++ b/plugin/skills/docs/SKILL.md
@@ -120,7 +120,11 @@ Report: "Document saved to: {path}"
 ## MCP Integration (if available)
 
 - **Linear**: Reference project documents and link generated docs to issues
-- **claude-mem**: Search for past documentation patterns. Save doc generation metadata at completion.
+- **claude-mem**: Search for past documentation patterns.
+
+## Work Summary
+
+Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
 
 ## Placeholder Patterns
 

--- a/plugin/skills/facilitate/SKILL.md
+++ b/plugin/skills/facilitate/SKILL.md
@@ -86,9 +86,11 @@ Read from `~/.claude/circle/projects/{project}/output/`:
 
 5. **MCP Integration** (if available):
    - **Linear**: Create cycle, assign bets as issues (interactive)
-   - **claude-mem**: Search for past cycle plans. Save cycle commitments.
+   - **claude-mem**: Search for past cycle plans.
 
-6. **Handoff**:
+6. **Work Summary**: Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
+
+7. **Handoff**:
    > **Facilitator — Complete.**
    > Cycle plan saved to: `~/.claude/circle/projects/{project}/output/facilitate/cycle-plan-{date}.md`
    > Bets committed: {count}

--- a/plugin/skills/impl/SKILL.md
+++ b/plugin/skills/impl/SKILL.md
@@ -132,9 +132,11 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
 11. **MCP Integration** (if available):
     - **Domain-specific tools**: If domain-specific MCP tools are available (configured via deps-manifest.yaml), use them to look up framework documentation and platform best practices.
     - **Linear**: Update issue status, comment on implementation progress
-    - **claude-mem**: Search for past implementation patterns. Save key decisions at completion.
+    - **claude-mem**: Search for past implementation patterns.
 
-12. **Handoff**:
+12. **Work Summary**: Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
+
+13. **Handoff**:
    > **Implementer — Complete.**
    > Output saved to: `~/.claude/circle/projects/{project}/output/impl/`
    > Next suggested role: `/circle:qa` for testing and validation.

--- a/plugin/skills/prioritize/SKILL.md
+++ b/plugin/skills/prioritize/SKILL.md
@@ -97,9 +97,11 @@ Read from `~/.claude/circle/projects/{project}/output/`:
 
 6. **MCP Integration** (if available):
    - **Linear**: Create issues from pitches, set priorities. Full access to issue management.
-   - **claude-mem**: Search for past product decisions and roadmap context. Save prioritization rationale at completion.
+   - **claude-mem**: Search for past product decisions and roadmap context.
 
-7. **Handoff**:
+7. **Work Summary**: Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
+
+8. **Handoff**:
    > **Prioritizer — Complete.**
    > Output saved to: `~/.claude/circle/projects/{project}/output/prioritize/PRD-{date}.md`
    > Pitches: {count}, Must Have: {count}, Should Have: {count}

--- a/plugin/skills/qa/SKILL.md
+++ b/plugin/skills/qa/SKILL.md
@@ -333,9 +333,11 @@ Run when invoked with `/circle:qa lint`. Validates internal consistency of the C
 
 9. **MCP Integration** (if available):
    - **Linear**: Link test results to issues, comment on verification outcomes
-   - **claude-mem**: Search for past test patterns. Save test strategy decisions at completion.
+   - **claude-mem**: Search for past test patterns.
 
-10. **Handoff**:
+10. **Work Summary**: Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
+
+11. **Handoff**:
    > **Quality Guardian — Complete.**
    > Verdict: **{PASS/CONDITIONAL PASS/REJECT}**
    > Output saved to: `~/.claude/circle/projects/{project}/output/qa/`

--- a/plugin/skills/scope/SKILL.md
+++ b/plugin/skills/scope/SKILL.md
@@ -95,9 +95,11 @@ Detect the project domain by analyzing files in the current directory:
 
 6. **MCP Integration** (if available):
    - **Linear**: Create or link requirements to Linear issues for traceability
-   - **claude-mem**: Search for relevant past requirements work. Save key decisions at completion.
+   - **claude-mem**: Search for relevant past requirements work.
 
-7. **Handoff**:
+7. **Work Summary**: Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
+
+8. **Handoff**:
    > **Scope Clarifier — Complete.**
    > Output saved to: `~/.claude/circle/projects/{project}/output/scope/{filename}`
    > Next suggested role: `/circle:prioritize` for product prioritization, or `/circle:arch` for architecture design.

--- a/plugin/skills/security/SKILL.md
+++ b/plugin/skills/security/SKILL.md
@@ -106,16 +106,18 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
 
 9. **MCP Integration** (if available):
    - **Linear**: Link security findings to issues, create P0/P1 issues for critical findings
-   - **claude-mem**: Search for past security patterns. Save key findings at completion.
+   - **claude-mem**: Search for past security patterns.
 
-10. **Security Gate Decision**:
+10. **Work Summary**: Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
+
+11. **Security Gate Decision**:
 
 Based on findings, determine the verdict:
 - If ANY **P0** finding → verdict is **SECURITY BLOCK**
 - If P1 but no P0 → verdict is **SECURITY PASS with warnings**
 - If only P2/P3 → verdict is **SECURITY PASS**
 
-11. **Handoff**:
+12. **Handoff**:
 
 **If SECURITY BLOCK:**
 > **Security Guardian — BLOCKED (P0 critical issues).**

--- a/plugin/skills/track/SKILL.md
+++ b/plugin/skills/track/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: track
+description: Capture work done outside Circle skills for assessment tracking. Interactive 3-question flow.
+allowed-tools: Read
+metadata:
+  context: same
+---
+
+# Work Tracker
+
+Capture work that doesn't flow through other Circle skills — ad-hoc debugging, mentoring, cross-team collaboration, manual reviews, production incidents, or any other meaningful activity.
+
+## Process
+
+1. **Read the template**: Read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` for the output format. If not found, use the format below directly.
+
+2. **Gather details** with 3 focused questions:
+
+   **Q1**: "What did you work on? (deliverable, task, activity — be specific about the project and what you produced or accomplished)"
+
+   Wait for the user's response.
+
+   **Q2**: "What decisions did you make or challenges did you navigate? (technical choices, trade-offs, blockers resolved)"
+
+   Wait for the user's response.
+
+   **Q3**: "What was the outcome? (result achieved, status change, impact on team or project)"
+
+   Wait for the user's response.
+
+3. **Compose and output** a Work Summary block using the template:
+
+   ```
+   ### Work Summary
+   - **Role**: manual-track | **Project**: {project from user's answer}
+   - **Deliverable**: {from Q1}
+   - **Key decisions**: {from Q2}
+   - **Approach**: {inferred from Q1 + Q2}
+   - **Outcome**: {from Q3}
+   - **Initiative**: {inferred — what was self-directed or proactive in the user's answers}
+   ```
+
+   Make each field concrete and specific. Rephrase the user's answers into dense, factual statements. Do not pad with filler.
+
+4. **Confirm**: "Captured. claude-mem will index this in the current session."
+
+## Notes
+
+- Keep it fast — the whole interaction should feel like 30 seconds, not a form
+- If the user provides all details in one message, skip remaining questions and go straight to the Work Summary
+- This skill produces no file output — the value is the structured text that claude-mem's session hooks capture automatically

--- a/plugin/skills/triage/SKILL.md
+++ b/plugin/skills/triage/SKILL.md
@@ -285,6 +285,10 @@ Extract actionable learnings from the review:
 - #Z: @author — [summary of what was asked]
 ```
 
+## Work Summary
+
+Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
+
 ## Handoff
 
 After completing the triage:

--- a/plugin/skills/ux/SKILL.md
+++ b/plugin/skills/ux/SKILL.md
@@ -77,9 +77,11 @@ Read from `~/.claude/circle/projects/{project}/output/`:
 8. **MCP Integration** (if available):
    - **Domain-specific tools**: If domain-specific MCP tools are available (configured via deps-manifest.yaml), use them to look up platform design guidelines and UI component patterns.
    - **Linear**: Reference and link design decisions to issues
-   - **claude-mem**: Search for past UX decisions. Save key design choices at completion.
+   - **claude-mem**: Search for past UX decisions.
 
-9. **Handoff**:
+9. **Work Summary**: Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
+
+10. **Handoff**:
    > **Experience Designer — Complete.**
    > Output saved to: `~/.claude/circle/projects/{project}/output/ux/{filename}`
    > Next suggested role: `/circle:arch` for architecture design.


### PR DESCRIPTION
## Summary
- All 12 role skills now produce enriched **Work Summary** blocks at handoff, automatically captured by claude-mem session hooks
- New `/circle:track` skill for manual capture of work outside Circle (debugging, mentoring, cross-team)
- New `resources/work-summary-template.md` with 6 fields aligned to assessment dimensions (Mastery, Autonomy, Impact, Ownership)
- Feeds `/assessment-daily` in luscii-matrix for Expert/Core & Master self-assessment
- Version bump 1.0.0 → 1.1.0

## Test plan
- [ ] Run `/circle:arch` on a project and verify Work Summary block appears before handoff
- [ ] Run `/circle:track` and verify 3-question interactive flow produces structured output
- [ ] Verify `/circle:circle` dashboard lists `/circle:track` in Utilities
- [ ] Verify `assessment-daily` finds richer observations from today's Circle work
- [ ] Sync Luscii/claude-marketplace with v1.1.0 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)