### PR TITLE
feat: effort routing and worktree parallel implementation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "circle",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "source": "./plugin",
       "description": "18 skills (9 holacracy roles + 9 utilities) with structured workflows, quality gates, self-verification guardrails, anti-overcomplication checks, TDD enforcement, security audits, work tracking, and full customization"
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Circle Plugin
 
-Pure Markdown plugin for Claude Code. 17 skills (9 holacracy roles + 8 utilities). No build, no tests, no CI.
+Pure Markdown plugin for Claude Code. 18 skills (9 holacracy roles + 9 utilities). No build, no tests, no CI.
 
 ## Dev
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v1.2.0 — Effort Routing & Parallel Implementation
+
+### Effort Routing
+
+Per-role effort level configuration alongside existing model routing. Each fork-context role declares a default effort level (`low`, `medium`, `high`, `max`) in its frontmatter metadata. Greenfield displays effort in step headers and persists it in session-state.json.
+
+- **9 fork-context skills updated** — scope, prioritize, validate-prd, ux, arch, security, facilitate, impl, qa now declare `metadata.effort`
+- **Greenfield model routing table** — expanded to show default effort per role
+- **session-state.json** — new `effort_routing` map alongside `model_routing`
+- **config.yaml** — `agents.<name>.effort` override per project
+- **Precedence**: config.yaml > session-state.json > skill frontmatter default
+
+### Worktree Parallel Implementation
+
+When stories are sharded, greenfield can implement independent stories in parallel using git worktrees. The orchestrator builds a dependency DAG from story shards, groups independent stories into execution waves, and launches up to 3 concurrent impl agents in isolated worktrees.
+
+- **Dependency graph** — parses `Dependencies` from story shards, filters to story-to-story deps only
+- **Wave execution** — independent stories grouped into parallel batches (max `parallel.max_agents`)
+- **Automatic merge** — `git merge --no-ff` per completed worktree, preserving per-story commit history
+- **Conflict handling** — merge conflicts pause the workflow with clear resolution instructions
+- **config.yaml** — `parallel.enabled` (default: true) and `parallel.max_agents` (default: 3)
+- **Graceful fallback** — no shards or parallel disabled → sequential impl as before
+
 ## v1.1.0 — Work Tracking
 
 ### Assessment-Aware Work Tracking

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -19,7 +19,7 @@ If you just want to tweak how Circle works for your project, here are the most c
 | Layer | What | Where | Friction |
 |---|---|---|---|
 | **Soul** | Team principles | `plugin/resources/soul.md` | Edit file, instant effect |
-| **Knowledge Pack** | Project-aware roles | `docs/bmad/` in your repo | Create Markdown files |
+| **Knowledge Pack** | Project-aware roles | `docs/circle/` in your repo | Create Markdown files |
 | **Per-project config** | Role overrides, templates | `~/.claude/circle/projects/<project>/config.yaml` | Create YAML file |
 | **Role behavior** | Role definitions | `plugin/skills/<name>/SKILL.md` | Edit SKILL.md |
 | **Templates** | Document templates | `plugin/resources/templates/` | Drop .md file |
@@ -34,7 +34,7 @@ A Knowledge Pack makes Circle understand your project. It's a set of Markdown fi
 
 ### Step 1: Create knowledge files
 
-Create `docs/bmad/` (or `Docs/bmad/`) in your repo with these files:
+Create `docs/circle/` (or `Docs/circle/`) in your repo with these files:
 
 | File | What to include | Target size |
 |---|---|---|
@@ -47,7 +47,7 @@ Create `docs/bmad/` (or `Docs/bmad/`) in your repo with these files:
 Each file starts with a metadata comment for staleness tracking:
 
 ```markdown
-<!-- bmad-knowledge | last-reviewed: 2026-03-04 | owner: @yourhandle -->
+<!-- circle-knowledge | last-reviewed: 2026-03-04 | owner: @yourhandle -->
 # Your Title
 
 Content organized with ## headers...
@@ -56,12 +56,12 @@ Content organized with ## headers...
 For cross-platform projects sharing domain vocabulary, add a sync marker:
 
 ```markdown
-<!-- shared-origin: my-domain | sync-with: other-repo/docs/bmad/domain.md -->
+<!-- shared-origin: my-domain | sync-with: other-repo/docs/circle/domain.md -->
 ```
 
 ### Step 2: Create config template
 
-Add `docs/bmad/config.yaml` to your repo. This maps knowledge files to Circle roles:
+Add `docs/circle/config.yaml` to your repo. This maps knowledge files to Circle roles:
 
 ```yaml
 project:
@@ -75,56 +75,56 @@ reading_order:
 agents:
   scope:
     context_files:
-      - docs/bmad/project.md
-      - docs/bmad/domain.md
+      - docs/circle/project.md
+      - docs/circle/domain.md
 
   arch:
     context_files:
-      - docs/bmad/project.md
-      - docs/bmad/domain.md
-      - docs/bmad/architecture.md
-      - docs/bmad/integrations.md
+      - docs/circle/project.md
+      - docs/circle/domain.md
+      - docs/circle/architecture.md
+      - docs/circle/integrations.md
     extra_instructions: |
       Use domain-specific skills for architecture decisions.
 
   impl:
     context_files:
-      - docs/bmad/project.md
-      - docs/bmad/domain.md
-      - docs/bmad/architecture.md
-      - docs/bmad/build.md
-      - docs/bmad/integrations.md
+      - docs/circle/project.md
+      - docs/circle/domain.md
+      - docs/circle/architecture.md
+      - docs/circle/build.md
+      - docs/circle/integrations.md
     extra_instructions: |
       Run build verification before committing.
 
   qa:
     context_files:
-      - docs/bmad/project.md
-      - docs/bmad/domain.md
-      - docs/bmad/architecture.md
-      - docs/bmad/build.md
+      - docs/circle/project.md
+      - docs/circle/domain.md
+      - docs/circle/architecture.md
+      - docs/circle/build.md
 
   code-review:
     context_files:
-      - docs/bmad/project.md
-      - docs/bmad/architecture.md
-      - docs/bmad/build.md
+      - docs/circle/project.md
+      - docs/circle/architecture.md
+      - docs/circle/build.md
 
   ux:
     context_files:
-      - docs/bmad/project.md
-      - docs/bmad/domain.md
+      - docs/circle/project.md
+      - docs/circle/domain.md
 
   security:
     context_files:
-      - docs/bmad/project.md
-      - docs/bmad/architecture.md
-      - docs/bmad/integrations.md
+      - docs/circle/project.md
+      - docs/circle/architecture.md
+      - docs/circle/integrations.md
 ```
 
 ### Step 3: Activate
 
-Run `/circle:init`. It detects the config template at `docs/bmad/config.yaml` and copies it to `~/.claude/circle/projects/<project>/config.yaml`. Every Circle role now loads project knowledge automatically.
+Run `/circle:init`. It detects the config template at `docs/circle/config.yaml` and copies it to `~/.claude/circle/projects/<project>/config.yaml`. Every Circle role now loads project knowledge automatically.
 
 New team members: clone the repo → `/circle:init` → done.
 
@@ -190,6 +190,8 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork            # fork = isolated subagent | same = main conversation
   agent: general-purpose   # Explore, Plan, qa, or general-purpose
+  model: sonnet            # opus, sonnet, or haiku
+  effort: medium           # low, medium, high, or max
 ---
 
 # <Role Name>

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -254,22 +254,23 @@ To add a new role to the greenfield orchestrator:
 
 ---
 
-## 7. Model Routing
+## 7. Model & Effort Routing
 
-Circle assigns a default Claude model to each fork-context role based on task complexity. Opus handles deep reasoning (architecture, security, implementation), Sonnet handles structured work (scope, prioritization, QA), and Haiku handles lightweight coordination.
+Circle assigns a default Claude model and effort level to each fork-context role based on task complexity. Model controls which Claude model runs; effort controls reasoning depth within that model.
 
 ### Default Assignments
 
-| Role | Default Model | Rationale |
-|------|--------------|-----------|
-| Scope Clarifier | sonnet | Structured requirements gathering |
-| Prioritizer | sonnet | Feature prioritization |
-| Experience Designer | sonnet | UX design patterns |
-| Architecture Owner | opus | Deep trade-off reasoning |
-| Security Guardian | opus | Adversarial threat modeling |
-| Facilitator | haiku | Lightweight coordination |
-| Implementer | opus | Code generation quality |
-| Quality Guardian | sonnet | Criteria-based validation |
+| Role | Default Model | Default Effort | Rationale |
+|------|--------------|----------------|-----------|
+| Scope Clarifier | sonnet | medium | Structured requirements gathering |
+| Prioritizer | sonnet | medium | Feature prioritization |
+| Experience Designer | sonnet | medium | UX design patterns |
+| Architecture Owner | opus | high | Deep trade-off reasoning |
+| Security Guardian | opus | high | Adversarial threat modeling |
+| Facilitator | haiku | low | Lightweight coordination |
+| Implementer | opus | high | Code generation quality |
+| PRD Validator | sonnet | low | Checklist-based validation |
+| Quality Guardian | sonnet | medium | Criteria-based validation |
 
 Code review agents (spawned by `code-review` via Task tool) also default to **sonnet**. Configure via `code_review.agent_a_model` and `code_review.agent_b_model` in config.yaml. Note: `code-review` itself is same-context and inherits the session model — only its spawned agents are configurable.
 
@@ -279,10 +280,13 @@ Code review agents (spawned by `code-review` via Task tool) also default to **so
 agents:
   arch:
     model: opus       # deep reasoning tasks
+    effort: high      # high reasoning depth
   scope:
     model: sonnet     # structured tasks
+    effort: medium    # moderate reasoning depth
   facilitate:
     model: haiku      # lightweight tasks
+    effort: low       # minimal reasoning depth
 
 # Code review agent models
 code_review:
@@ -290,15 +294,58 @@ code_review:
   agent_b_model: sonnet
 ```
 
+### Effort Levels
+
+| Level | Use for |
+|-------|---------|
+| `low` | Checklist validation, lightweight coordination, boilerplate |
+| `medium` | Structured gathering, prioritization, criteria-based QA |
+| `high` | Architecture design, security modeling, code generation |
+| `max` | Complex multi-system reasoning (use sparingly) |
+
+**Precedence**: config.yaml > session-state.json > skill frontmatter default
+
 ### How It Works
 
-- **Fork-context skills** (`context: fork`) specify `model:` in frontmatter metadata. Orchestrators pass this to the Task tool's `model` parameter.
+- **Fork-context skills** (`context: fork`) specify `model:` and `effort:` in frontmatter metadata. Orchestrators pass these when presenting role invocations.
 - **Same-context skills** (`context: same`) inherit the session model and cannot be overridden.
-- **Config overrides** take precedence over frontmatter defaults.
+- **Config overrides** take precedence over frontmatter defaults for both model and effort.
 
 ### Cost Implications
 
-Model routing lets you optimize cost without sacrificing quality where it matters. Approximate relative cost per token: Opus (5x), Sonnet (1x), Haiku (0.2x).
+Model and effort routing let you optimize cost without sacrificing quality where it matters. Approximate relative cost per token: Opus (5x), Sonnet (1x), Haiku (0.2x). Higher effort levels increase token usage within a session.
+
+---
+
+## 8. Parallel Implementation
+
+When stories are sharded (via `/circle:shard`), greenfield can implement independent stories in parallel using git worktrees. This reduces wall-clock time for multi-story features.
+
+### How It Works
+
+1. Greenfield detects `shards/stories/` with ≥2 story files
+2. Parses `Dependencies` from each story shard
+3. Builds a dependency graph (story-to-story deps only)
+4. Groups independent stories into parallel waves (max 3 concurrent)
+5. Launches impl agents in isolated worktrees
+6. Merges completed worktrees into the feature branch via `git merge --no-ff`
+7. Pauses on merge conflicts for manual resolution
+
+### Configuration
+
+```yaml
+parallel:
+  enabled: true       # default: true (disable to force sequential impl)
+  max_agents: 3       # default: 3, max concurrent worktree agents
+```
+
+### When It Activates
+
+Parallel impl runs only when:
+- `shards/stories/` exists with ≥2 story files
+- `parallel.enabled` is not `false` in config.yaml
+
+Otherwise, greenfield falls back to sequential implementation silently.
 
 ---
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "circle",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Holacracy-based development workflow with distributed roles, quality gates, and Shape Up planning",
   "author": {
     "name": "Alessio Roberto",

--- a/plugin/resources/templates/config-example.yaml
+++ b/plugin/resources/templates/config-example.yaml
@@ -37,19 +37,24 @@ tdd:
   enabled: true           # Enable TDD workflow (default: true)
   enforcement: hard       # hard = QA blocks on violation; soft = QA warns only
 
-# Model routing — assign Claude model per role (opus, sonnet, haiku)
-# Roles with context: fork run as subagents and respect this setting.
-# Roles with context: same inherit the session model (setting is ignored).
-# Default: inherits from session (usually opus).
+# Model & effort routing — assign Claude model and effort level per role
+# Roles with context: fork run as subagents and respect these settings.
+# Roles with context: same inherit the session model (settings are ignored).
+# Model default: inherits from session (usually opus).
+# Effort levels: low, medium, high, max (controls reasoning depth).
+# Effort precedence: config.yaml > session-state.json > skill frontmatter default.
 #
-# Role overrides — add model, extra context, or instructions per role
+# Role overrides — add model, effort, extra context, or instructions per role
 agents:
   scope:
     model: sonnet
+    effort: medium
   prioritize:
     model: sonnet
+    effort: medium
   arch:
     model: opus
+    effort: high
     # Additional files to read for architectural context
     context_files:
       - docs/ARCHITECTURE.md
@@ -60,12 +65,16 @@ agents:
       All new modules must follow the existing pattern.
   validate-prd:
     model: sonnet
+    effort: low
   security:
     model: opus
+    effort: high
   facilitate:
     model: haiku
+    effort: low
   impl:
     model: opus
+    effort: high
     context_files:
       - src/
     extra_instructions: |
@@ -73,14 +82,24 @@ agents:
       All public APIs must have documentation comments.
   qa:
     model: sonnet
+    effort: medium
     extra_instructions: |
       Minimum test coverage target: 80%.
       Focus on integration tests for data flows.
   ux:
     model: sonnet
+    effort: medium
     extra_instructions: |
       Follow platform design guidelines.
       Support accessibility features.
+
+# Parallel implementation — worktree-based parallel execution of sharded stories
+# When stories are sharded (via /circle:shard), greenfield can implement
+# independent stories in parallel using git worktrees.
+# Requires: shards/stories/ with ≥2 story files.
+parallel:
+  enabled: true           # Enable parallel impl (default: true)
+  max_agents: 3           # Max concurrent worktree agents (default: 3)
 
 # Code review agent models (code-review spawns 2 parallel agents)
 code_review:

--- a/plugin/skills/arch/SKILL.md
+++ b/plugin/skills/arch/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   context: fork
   agent: Plan
   model: opus
+  effort: high
 ---
 
 # Architecture Owner

--- a/plugin/skills/facilitate/SKILL.md
+++ b/plugin/skills/facilitate/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   context: fork
   agent: general-purpose
   model: haiku
+  effort: low
 ---
 
 # Facilitator

--- a/plugin/skills/greenfield/SKILL.md
+++ b/plugin/skills/greenfield/SKILL.md
@@ -47,23 +47,27 @@ Detect the project domain by analyzing files in the current directory:
 - **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
 - **general**: default if no software indicator found
 
-## Model Routing
+## Model & Effort Routing
 
-Each role runs with a recommended Claude model. The orchestrator passes the `model` parameter when presenting role invocations. Users can override per-project in `config.yaml`.
+Each role runs with a recommended Claude model and effort level. The orchestrator passes both `model` and effort parameters when presenting role invocations. Users can override per-project in `config.yaml`.
 
-| Role | Default Model | Rationale |
-|------|--------------|-----------|
-| Scope Clarifier | sonnet | Structured requirements gathering |
-| Prioritizer | sonnet | Feature prioritization |
-| Experience Designer | sonnet | UX design patterns |
-| Architecture Owner | opus | Deep trade-off reasoning |
-| Security Guardian | opus | Adversarial threat modeling |
-| Facilitator | haiku | Lightweight coordination |
-| Implementer | opus | Code generation quality |
-| PRD Validator | sonnet | Structured criteria-based validation |
-| Quality Guardian | sonnet | Criteria-based validation |
+| Role | Default Model | Default Effort | Rationale |
+|------|--------------|----------------|-----------|
+| Scope Clarifier | sonnet | medium | Structured requirements gathering |
+| Prioritizer | sonnet | medium | Feature prioritization |
+| Experience Designer | sonnet | medium | UX design patterns |
+| Architecture Owner | opus | high | Deep trade-off reasoning |
+| Security Guardian | opus | high | Adversarial threat modeling |
+| Facilitator | haiku | low | Lightweight coordination |
+| Implementer | opus | high | Code generation quality |
+| PRD Validator | sonnet | low | Structured criteria-based validation |
+| Quality Guardian | sonnet | medium | Criteria-based validation |
 
-**Config override**: `agents.{name}.model` in `~/.claude/circle/projects/{project}/config.yaml`
+**Effort levels**: `low`, `medium`, `high`, `max` — controls reasoning depth per role.
+
+**Config override**: `agents.{name}.model` and `agents.{name}.effort` in `~/.claude/circle/projects/{project}/config.yaml`
+
+**Effort precedence**: config.yaml > session-state.json > skill frontmatter default
 
 ---
 
@@ -145,6 +149,17 @@ Optional phases:
       "impl": "opus",
       "qa": "sonnet"
     },
+    "effort_routing": {
+      "scope": "medium",
+      "prioritize": "medium",
+      "validate-prd": "low",
+      "ux": "medium",
+      "arch": "high",
+      "security": "high",
+      "facilitate": "low",
+      "impl": "high",
+      "qa": "medium"
+    },
     "step_sequence": ["init", "scope", "prioritize", ...],
     "checkpoints": [
       {
@@ -167,10 +182,10 @@ For each step in the sequence, follow this protocol:
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Step {N}/{total}: {Role Name} [{model}]
+Step {N}/{total}: {Role Name} [{model}] [{effort}]
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Purpose: {What this role will do}
-Model: {opus|sonnet|haiku} (override in config.yaml)
+Model: {opus|sonnet|haiku} | Effort: {low|medium|high|max}
 Input: {What artifacts from previous steps are available}
 Output: {What artifact this role will produce}
 
@@ -188,17 +203,17 @@ After completion, type one of:
 
 ### Role Sequence Detail
 
-| Step | Role | Model | Purpose | Input | Output |
-|---|---|---|---|---|---|
-| 1 | **Scope Clarifier** | sonnet | Gather requirements | User description | `scope/requirements.md` |
-| 2 | **Prioritizer** | sonnet | Prioritize & create PRD | Requirements | `prioritize/PRD-{date}.md` |
-| 3* | **PRD Validator** | sonnet | Validate PRD quality | PRD + Requirements | `qa/prd-validation-report.md` |
-| 4* | **Experience Designer** | sonnet | Design UX | PRD | `ux/ux-design.md` |
-| 5 | **Architecture Owner** | opus | Design architecture | PRD + UX (if available) | `arch/architecture.md` |
-| 6 | **Security Guardian** | opus | Security audit | Architecture | `security/security-audit.md` |
-| 7* | **Facilitator** | haiku | Cycle planning | PRD + Architecture | `facilitate/cycle-plan.md` |
-| 8 | **Implementer** | opus | Implement | Architecture + PRD | Code in repo |
-| 9 | **Quality Guardian** | sonnet | Test & validate | Requirements + Code | `qa/test-report-{date}.md` |
+| Step | Role | Model | Effort | Purpose | Input | Output |
+|---|---|---|---|---|---|---|
+| 1 | **Scope Clarifier** | sonnet | medium | Gather requirements | User description | `scope/requirements.md` |
+| 2 | **Prioritizer** | sonnet | medium | Prioritize & create PRD | Requirements | `prioritize/PRD-{date}.md` |
+| 3* | **PRD Validator** | sonnet | low | Validate PRD quality | PRD + Requirements | `qa/prd-validation-report.md` |
+| 4* | **Experience Designer** | sonnet | medium | Design UX | PRD | `ux/ux-design.md` |
+| 5 | **Architecture Owner** | opus | high | Design architecture | PRD + UX (if available) | `arch/architecture.md` |
+| 6 | **Security Guardian** | opus | high | Security audit | Architecture | `security/security-audit.md` |
+| 7* | **Facilitator** | haiku | low | Cycle planning | PRD + Architecture | `facilitate/cycle-plan.md` |
+| 8 | **Implementer** | opus | high | Implement | Architecture + PRD | Code in repo |
+| 9 | **Quality Guardian** | sonnet | medium | Test & validate | Requirements + Code | `qa/test-report-{date}.md` |
 
 *Optional steps
 
@@ -388,11 +403,113 @@ Run sharding? [y/n]
 → /circle:shard
 ```
 
-If sharding is enabled, the Implementer step will prompt:
+If sharding is enabled and parallel execution is disabled, the Implementer step will prompt:
 ```
 Shards available. Which story should the Implementer work on?
 → /circle:impl STORY-001
 ```
+
+---
+
+## Parallel Implementation
+
+When shards exist and the impl step is reached, the orchestrator can launch independent stories in parallel using git worktrees.
+
+### Activation Conditions
+
+Parallel impl activates only when ALL of these are true:
+1. `shards/stories/` directory exists with ≥2 story files
+2. `parallel.enabled` is not `false` in config.yaml (default: true)
+
+When either condition fails, fall back to sequential impl (current behavior, no warning).
+
+### Dependency Graph
+
+1. Read all files in `$BASE/shards/stories/`
+2. Parse the `**Dependencies**:` field from each story shard
+3. Filter to **story-to-story dependencies only** (ADR/FR references are informational, not blocking)
+4. Build a DAG of story dependencies
+5. Group stories into execution waves:
+   - **Wave 1**: stories with zero unresolved story dependencies
+   - **Wave 2**: stories whose deps are all in wave 1
+   - ...and so on
+6. Stories without a Dependencies field are treated as independent (wave 1)
+
+### Execution Protocol
+
+1. Display the wave plan to the user:
+   ```
+   Parallel implementation plan:
+   Wave 1 (parallel, max {max_agents}): STORY-001, STORY-002, STORY-003
+   Wave 2 (after wave 1): STORY-004
+   Proceed? [y/n]
+   ```
+
+2. For each wave:
+   a. Launch `min(wave_size, parallel.max_agents)` Task agents in a single message:
+      - Each with `isolation: "worktree"`
+      - Each with prompt: `/circle:impl STORY-xxx`
+      - Each with `model` from model_routing and effort from effort_routing
+   b. Wait for all agents in the wave to complete
+   c. For each completed agent, merge into the feature branch:
+      ```
+      git merge <worktree-branch> --no-ff -m "merge: STORY-xxx implementation"
+      ```
+   d. If merge succeeds: log in session-state checkpoints, clean up worktree
+   e. If merge conflicts: **pause workflow**, display conflict details:
+      ```
+      MERGE CONFLICT — STORY-xxx
+      Conflicting files:
+        - {file1}
+        - {file2}
+
+      Resolve conflicts manually, then type 'next' to continue merging.
+      ```
+   f. After all merges in wave complete, advance to next wave
+
+3. After all waves complete: advance to QA step
+
+### Parallel Configuration
+
+Read from config.yaml:
+```yaml
+parallel:
+  enabled: true       # default: true
+  max_agents: 3       # default: 3, max concurrent worktree agents
+```
+
+### Session State for Parallel Execution
+
+When parallel impl is active, add to session-state.json:
+```json
+{
+  "parallel": {
+    "enabled": true,
+    "max_agents": 3,
+    "waves": [
+      {
+        "wave": 1,
+        "stories": ["STORY-001", "STORY-002", "STORY-003"],
+        "status": "completed"
+      },
+      {
+        "wave": 2,
+        "stories": ["STORY-004"],
+        "status": "pending"
+      }
+    ]
+  }
+}
+```
+
+### Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Merge conflict | Pause workflow, show conflict files, wait for user resolution |
+| Agent failure | Log failure, continue other agents in wave, report at wave end |
+| All agents in wave fail | Pause workflow, suggest manual intervention |
+| Invalid effort value in config | Warn, fall back to skill frontmatter default |
 
 ---
 

--- a/plugin/skills/impl/SKILL.md
+++ b/plugin/skills/impl/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   context: fork
   agent: general-purpose
   model: opus
+  effort: high
 ---
 
 # Implementer

--- a/plugin/skills/prioritize/SKILL.md
+++ b/plugin/skills/prioritize/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   context: fork
   agent: general-purpose
   model: sonnet
+  effort: medium
 ---
 
 # Prioritizer

--- a/plugin/skills/qa/SKILL.md
+++ b/plugin/skills/qa/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   context: fork
   agent: qa
   model: sonnet
+  effort: medium
 ---
 
 # Quality Guardian

--- a/plugin/skills/scope/SKILL.md
+++ b/plugin/skills/scope/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   context: fork
   agent: Explore
   model: sonnet
+  effort: medium
 ---
 
 # Scope Clarifier

--- a/plugin/skills/security/SKILL.md
+++ b/plugin/skills/security/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   context: fork
   agent: qa
   model: opus
+  effort: high
 ---
 
 # Security Guardian

--- a/plugin/skills/ux/SKILL.md
+++ b/plugin/skills/ux/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   context: fork
   agent: Plan
   model: sonnet
+  effort: medium
 ---
 
 # Experience Designer

--- a/plugin/skills/validate-prd/SKILL.md
+++ b/plugin/skills/validate-prd/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   context: fork
   agent: qa
   model: sonnet
+  effort: low
 ---
 
 # PRD Validator


### PR DESCRIPTION
## Summary
- Add per-role effort level configuration (`low`/`medium`/`high`/`max`) alongside existing model routing — 9 fork-context skills updated with default effort in frontmatter, greenfield displays effort in step headers, session-state.json tracks `effort_routing`
- Add worktree-based parallel implementation for sharded stories — greenfield builds a dependency DAG, groups independent stories into execution waves (max 3 concurrent), launches impl agents in isolated worktrees with automatic `git merge --no-ff`
- New config options: `agents.<name>.effort` and `parallel.enabled`/`parallel.max_agents`

## Test plan
- [ ] Verify greenfield workflow displays effort level in step headers
- [ ] Verify config.yaml effort overrides take precedence over frontmatter defaults
- [ ] Verify parallel impl activates only with ≥2 story shards
- [ ] Verify sequential fallback when `parallel.enabled: false`
- [ ] Verify merge conflict pauses workflow with instructions
- [ ] Run `/circle:qa lint` to validate plugin consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)