### PR TITLE
feat!: replace Agile terminology with Holacracy-aligned vocabulary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "circle",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "source": "./plugin",
       "description": "18 skills (9 holacracy roles + 9 utilities) with structured workflows, quality gates, self-verification guardrails, anti-overcomplication checks, TDD enforcement, security audits, work tracking, and full customization"
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@
 - PRD template: `## User Stories` → `## Work Items`, `### Epic` → `### Initiative`, `US-x.x` → `WI-x.x`
 
 ### Files changed
-- 11 skill files updated (shard, greenfield, validate-prd, impl, qa, tdd, init, cycle, scope, prioritize, docs)
+- 10 skill files updated (shard, greenfield, validate-prd, impl, qa, tdd, init, cycle, scope, prioritize)
 - `resources/guardrails.md` — upstream artifact mapping
 - `resources/templates/software/PRD.md` — PRD template
 - `resources/templates/config-example.yaml` — parallel config comments

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v1.3.0 — Holacracy Terminology Alignment
+
+**BREAKING**: Agile/Scrum terminology replaced with Holacracy-aligned vocabulary across all skills. Users with existing `shards/stories/` directories must re-run `/circle:shard` to regenerate under `shards/tasks/`.
+
+### Terminology changes
+- `STORY-xxx` → `TASK-xxx` (shard prefix)
+- `shards/stories/` → `shards/tasks/` (directory)
+- `user story` → `work item` (concept)
+- `epic` → `initiative` (grouping)
+- `story points` removed (Agile-specific metric)
+- `"As a user, I want to..."` → purpose-driven format: `"Enable {actor} to {action} for {outcome}"`
+- PRD template: `## User Stories` → `## Work Items`, `### Epic` → `### Initiative`, `US-x.x` → `WI-x.x`
+
+### Files changed
+- 11 skill files updated (shard, greenfield, validate-prd, impl, qa, tdd, init, cycle, scope, prioritize, docs)
+- `resources/guardrails.md` — upstream artifact mapping
+- `resources/templates/software/PRD.md` — PRD template
+- `resources/templates/config-example.yaml` — parallel config comments
+- `commands/circle.md` — dashboard description
+
 ## v1.2.0 — Effort Routing & Parallel Implementation
 
 ### Effort Routing
@@ -14,11 +34,11 @@ Per-role effort level configuration alongside existing model routing. Each fork-
 
 ### Worktree Parallel Implementation
 
-When stories are sharded, greenfield can implement independent stories in parallel using git worktrees. The orchestrator builds a dependency DAG from story shards, groups independent stories into execution waves, and launches up to 3 concurrent impl agents in isolated worktrees.
+When work items are sharded, greenfield can implement independent tasks in parallel using git worktrees. The orchestrator builds a dependency DAG from task shards, groups independent tasks into execution waves, and launches up to 3 concurrent impl agents in isolated worktrees.
 
-- **Dependency graph** — parses `Dependencies` from story shards, filters to story-to-story deps only
-- **Wave execution** — independent stories grouped into parallel batches (max `parallel.max_agents`)
-- **Automatic merge** — `git merge --no-ff` per completed worktree, preserving per-story commit history
+- **Dependency graph** — parses `Dependencies` from task shards, filters to task-to-task deps only
+- **Wave execution** — independent tasks grouped into parallel batches (max `parallel.max_agents`)
+- **Automatic merge** — `git merge --no-ff` per completed worktree, preserving per-task commit history
 - **Conflict handling** — merge conflicts pause the workflow with clear resolution instructions
 - **config.yaml** — `parallel.enabled` (default: true) and `parallel.max_agents` (default: 3)
 - **Graceful fallback** — no shards or parallel disabled → sequential impl as before

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -321,14 +321,14 @@ Model and effort routing let you optimize cost without sacrificing quality where
 
 ## 8. Parallel Implementation
 
-When stories are sharded (via `/circle:shard`), greenfield can implement independent stories in parallel using git worktrees. This reduces wall-clock time for multi-story features.
+When work items are sharded (via `/circle:shard`), greenfield can implement independent tasks in parallel using git worktrees. This reduces wall-clock time for multi-task features.
 
 ### How It Works
 
-1. Greenfield detects `shards/stories/` with ≥2 story files
-2. Parses `Dependencies` from each story shard
-3. Builds a dependency graph (story-to-story deps only)
-4. Groups independent stories into parallel waves (max 3 concurrent)
+1. Greenfield detects `shards/tasks/` with ≥2 task files
+2. Parses `Dependencies` from each task shard
+3. Builds a dependency graph (task-to-task deps only)
+4. Groups independent tasks into parallel waves (max 3 concurrent)
 5. Launches impl agents in isolated worktrees
 6. Merges completed worktrees into the feature branch via `git merge --no-ff`
 7. Pauses on merge conflicts for manual resolution
@@ -344,7 +344,7 @@ parallel:
 ### When It Activates
 
 Parallel impl runs only when:
-- `shards/stories/` exists with ≥2 story files
+- `shards/tasks/` exists with ≥2 task files
 - `parallel.enabled` is not `false` in config.yaml
 
 Otherwise, greenfield falls back to sequential implementation silently.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -9,7 +9,7 @@ You talk to them using simple commands in Claude Code. No programming knowledge 
 Circle is designed for everyone involved in building a product:
 
 - **Product people** — define what to build, prioritize features, create roadmaps
-- **Analysts** — gather requirements, write user stories, clarify scope
+- **Analysts** — gather requirements, define work items, clarify scope
 - **Designers** — create UI/UX designs, map user journeys, build wireframes
 - **Coordinators** — plan work cycles, coordinate the team, track progress
 - **Developers** — implement features, review code, run tests

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "circle",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Holacracy-based development workflow with distributed roles, quality gates, and Shape Up planning",
   "author": {
     "name": "Alessio Roberto",

--- a/plugin/commands/circle.md
+++ b/plugin/commands/circle.md
@@ -34,7 +34,7 @@ What's next:
   <Or "Run /circle:greenfield for the full workflow">
 
 Your circle:
-  /circle:scope       — Scope Clarifier (requirements, user stories)
+  /circle:scope       — Scope Clarifier (requirements, work items)
   /circle:arch        — Architecture Owner (design, trade-offs)
   /circle:impl        — Implementer (implementation, code review)
   /circle:qa          — Quality Guardian (testing, quality)

--- a/plugin/resources/guardrails.md
+++ b/plugin/resources/guardrails.md
@@ -13,18 +13,18 @@ Before handoff, verify your output covers upstream requirements. This closes the
 
 | Your Role | Read This | Check For |
 |---|---|---|
-| arch | `scope/requirements.md` or `prioritize/PRD.md` | Each FR-*/user story addressed in architecture |
+| arch | `scope/requirements.md` or `prioritize/PRD.md` | Each FR-*/work item addressed in architecture |
 | impl | `arch/architecture.md` | Each component/module implemented |
 | qa | `scope/requirements.md` or `prioritize/PRD.md` | Each acceptance criterion has a test |
-| prioritize | `scope/requirements.md` | Each FR-* has a user story |
-| ux | `prioritize/PRD.md` | Each user story has UX coverage |
+| prioritize | `scope/requirements.md` | Each FR-* has a work item |
+| ux | `prioritize/PRD.md` | Each work item has UX coverage |
 | security | `arch/architecture.md` | Each component has threat analysis |
 
 Read the upstream artifact from `~/.claude/circle/projects/{project}/output/`. If the first path doesn't exist, try the alternative (e.g., PRD.md if requirements.md is missing).
 
 ### Protocol
 
-1. Extract the list of checkable items from the upstream artifact (FR-*, user stories, components, acceptance criteria — depending on your role's "Check For" column above).
+1. Extract the list of checkable items from the upstream artifact (FR-*, work items, components, acceptance criteria — depending on your role's "Check For" column above).
 2. For each item, assess coverage in your output:
    - ✅ **Covered** — explicitly addressed
    - ⚠️ **Partial** — mentioned but incomplete

--- a/plugin/resources/templates/config-example.yaml
+++ b/plugin/resources/templates/config-example.yaml
@@ -93,10 +93,10 @@ agents:
       Follow platform design guidelines.
       Support accessibility features.
 
-# Parallel implementation — worktree-based parallel execution of sharded stories
-# When stories are sharded (via /circle:shard), greenfield can implement
-# independent stories in parallel using git worktrees.
-# Requires: shards/stories/ with ≥2 story files.
+# Parallel implementation — worktree-based parallel execution of sharded tasks
+# When work items are sharded (via /circle:shard), greenfield can implement
+# independent tasks in parallel using git worktrees.
+# Requires: shards/tasks/ with ≥2 task files.
 parallel:
   enabled: true           # Enable parallel impl (default: true)
   max_agents: 3           # Max concurrent worktree agents (default: 3)

--- a/plugin/resources/templates/software/PRD.md
+++ b/plugin/resources/templates/software/PRD.md
@@ -10,23 +10,23 @@
 | {Goal 1} | {How to measure} | {Target value} |
 | {Goal 2} | {How to measure} | {Target value} |
 
-## User Stories
+## Work Items
 
-### Epic 1: {Name}
+### Initiative 1: {Name}
 
-**US-1.1**: As a {user type}, I want to {action}, so that {benefit}.
+**WI-1.1**: Enable {actor} to {action} for {outcome}.
 - Acceptance Criteria:
   - [ ] {Criterion 1}
   - [ ] {Criterion 2}
 
-**US-1.2**: As a {user type}, I want to {action}, so that {benefit}.
+**WI-1.2**: Enable {actor} to {action} for {outcome}.
 - Acceptance Criteria:
   - [ ] {Criterion 1}
   - [ ] {Criterion 2}
 
-### Epic 2: {Name}
+### Initiative 2: {Name}
 
-**US-2.1**: As a {user type}, I want to {action}, so that {benefit}.
+**WI-2.1**: Enable {actor} to {action} for {outcome}.
 - Acceptance Criteria:
   - [ ] {Criterion 1}
 

--- a/plugin/skills/cycle/SKILL.md
+++ b/plugin/skills/cycle/SKILL.md
@@ -71,7 +71,7 @@ Step 1/4: Shaping Review
 ```
 
 1. Read PRD and pitches, extract features as shaped ideas
-2. If shards exist in `~/.claude/circle/projects/{project}/shards/stories/`, list them
+2. If shards exist in `~/.claude/circle/projects/{project}/shards/tasks/`, list them
 3. Display ideas with shaped status:
 
 ```

--- a/plugin/skills/greenfield/SKILL.md
+++ b/plugin/skills/greenfield/SKILL.md
@@ -99,7 +99,7 @@ BASE=~/.claude/circle/projects/$PROJECT_NAME
 **Initialize structure**:
 ```bash
 mkdir -p $BASE/output/{scope,arch,impl,qa,security,ux,prioritize,facilitate,docs,code-review,triage}
-mkdir -p $BASE/shards/{requirements,architecture,stories}
+mkdir -p $BASE/shards/{requirements,architecture,tasks}
 mkdir -p $BASE/workspace
 ```
 
@@ -397,7 +397,7 @@ After the Prioritizer's PRD phase, if the PRD exceeds ~3000 tokens:
 
 ```
 The PRD is quite large ({token_estimate} tokens).
-Context sharding can split it into atomic stories for focused implementation.
+Context sharding can split it into atomic tasks for focused implementation.
 
 Run sharding? [y/n]
 → /circle:shard
@@ -405,60 +405,60 @@ Run sharding? [y/n]
 
 If sharding is enabled and parallel execution is disabled, the Implementer step will prompt:
 ```
-Shards available. Which story should the Implementer work on?
-→ /circle:impl STORY-001
+Shards available. Which task should the Implementer work on?
+→ /circle:impl TASK-001
 ```
 
 ---
 
 ## Parallel Implementation
 
-When shards exist and the impl step is reached, the orchestrator can launch independent stories in parallel using git worktrees.
+When shards exist and the impl step is reached, the orchestrator can launch independent tasks in parallel using git worktrees.
 
 ### Activation Conditions
 
 Parallel impl activates only when ALL of these are true:
-1. `shards/stories/` directory exists with ≥2 story files
+1. `shards/tasks/` directory exists with ≥2 task files
 2. `parallel.enabled` is not `false` in config.yaml (default: true)
 
 When either condition fails, fall back to sequential impl (current behavior, no warning).
 
 ### Dependency Graph
 
-1. Read all files in `$BASE/shards/stories/`
-2. Parse the `**Dependencies**:` field from each story shard
-3. Filter to **story-to-story dependencies only** (ADR/FR references are informational, not blocking)
-4. Build a DAG of story dependencies
-5. Group stories into execution waves:
-   - **Wave 1**: stories with zero unresolved story dependencies
-   - **Wave 2**: stories whose deps are all in wave 1
+1. Read all files in `$BASE/shards/tasks/`
+2. Parse the `**Dependencies**:` field from each task shard
+3. Filter to **task-to-task dependencies only** (ADR/FR references are informational, not blocking)
+4. Build a DAG of task dependencies
+5. Group tasks into execution waves:
+   - **Wave 1**: tasks with zero unresolved task dependencies
+   - **Wave 2**: tasks whose deps are all in wave 1
    - ...and so on
-6. Stories without a Dependencies field are treated as independent (wave 1)
+6. Tasks without a Dependencies field are treated as independent (wave 1)
 
 ### Execution Protocol
 
 1. Display the wave plan to the user:
    ```
    Parallel implementation plan:
-   Wave 1 (parallel, max {max_agents}): STORY-001, STORY-002, STORY-003
-   Wave 2 (after wave 1): STORY-004
+   Wave 1 (parallel, max {max_agents}): TASK-001, TASK-002, TASK-003
+   Wave 2 (after wave 1): TASK-004
    Proceed? [y/n]
    ```
 
 2. For each wave:
    a. Launch `min(wave_size, parallel.max_agents)` Task agents in a single message:
       - Each with `isolation: "worktree"`
-      - Each with prompt: `/circle:impl STORY-xxx`
+      - Each with prompt: `/circle:impl TASK-xxx`
       - Each with `model` from model_routing and effort from effort_routing
    b. Wait for all agents in the wave to complete
    c. For each completed agent, merge into the feature branch:
       ```
-      git merge <worktree-branch> --no-ff -m "merge: STORY-xxx implementation"
+      git merge <worktree-branch> --no-ff -m "merge: TASK-xxx implementation"
       ```
    d. If merge succeeds: log in session-state checkpoints, clean up worktree
    e. If merge conflicts: **pause workflow**, display conflict details:
       ```
-      MERGE CONFLICT — STORY-xxx
+      MERGE CONFLICT — TASK-xxx
       Conflicting files:
         - {file1}
         - {file2}
@@ -489,12 +489,12 @@ When parallel impl is active, add to session-state.json:
     "waves": [
       {
         "wave": 1,
-        "stories": ["STORY-001", "STORY-002", "STORY-003"],
+        "tasks": ["TASK-001", "TASK-002", "TASK-003"],
         "status": "completed"
       },
       {
         "wave": 2,
-        "stories": ["STORY-004"],
+        "tasks": ["TASK-004"],
         "status": "pending"
       }
     ]

--- a/plugin/skills/impl/SKILL.md
+++ b/plugin/skills/impl/SKILL.md
@@ -50,12 +50,12 @@ Also check for project config: `~/.claude/circle/projects/{project}/config.yaml`
 
 ## Progressive Disclosure (Context Sharding)
 
-If directory `~/.claude/circle/projects/{project}/shards/stories/` exists:
-- Accept parameter: `$ARGUMENTS` (e.g.: STORY-001)
-- Load ONLY the file: `~/.claude/circle/projects/{project}/shards/stories/$ARGUMENTS.md`
-- Do NOT load: other stories, full PRD, future tasks
+If directory `~/.claude/circle/projects/{project}/shards/tasks/` exists:
+- Accept parameter: `$ARGUMENTS` (e.g.: TASK-001)
+- Load ONLY the file: `~/.claude/circle/projects/{project}/shards/tasks/$ARGUMENTS.md`
+- Do NOT load: other tasks, full PRD, future work items
 - **Benefit**: 90% token reduction, absolute focus on current task
-- **Parallel execution**: When implementing independent stories in parallel, the orchestrator may pass `isolation: "worktree"` to the Task tool for branch isolation.
+- **Parallel execution**: When implementing independent tasks in parallel, the orchestrator may pass `isolation: "worktree"` to the Task tool for branch isolation.
 
 ## Domain-Specific Behavior
 
@@ -88,8 +88,8 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
 
    Read the architecture (`arch/architecture.md`) and PRD (`prioritize/PRD.md`), then assess:
 
-   **a) Scope check**: Does the design contain components, services, or modules not directly required by Must Have user stories? If yes, list them and ask the user:
-   > "These components are in the architecture but not traced to MVP user stories: {list}. Proceed with full design, or simplify?"
+   **a) Scope check**: Does the design contain components, services, or modules not directly required by Must Have work items? If yes, list them and ask the user:
+   > "These components are in the architecture but not traced to MVP work items: {list}. Proceed with full design, or simplify?"
 
    **b) Technology check**: Does the design introduce infrastructure (containers, orchestration, message queues, caching layers, managed services) not strictly necessary for an MVP? If yes, propose the simplest alternative:
    > "The architecture specifies {technology}. For MVP, {simpler alternative} would suffice. Proceed with original, or simplify?"
@@ -110,7 +110,7 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
      - If software domain but no test framework detected: prompt the user:
        > "TDD is enabled but no test runner was detected. Disable TDD for this session, or set up tests first? [disable/setup]"
      - If TDD applies: implement each unit of work via `/circle:tdd` sub-workflow.
-       For each feature, story, or bugfix: invoke the TDD cycle (red → green → refactor).
+       For each feature, work item, or bugfix: invoke the TDD cycle (red → green → refactor).
        Do NOT write implementation code before writing tests.
        After all TDD cycles complete, skip to step 7 (self-review).
 

--- a/plugin/skills/init/SKILL.md
+++ b/plugin/skills/init/SKILL.md
@@ -138,7 +138,7 @@ PROJECT_NAME=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
 BASE=~/.claude/circle/projects/$PROJECT_NAME
 
 mkdir -p $BASE/output/{scope,arch,impl,qa,security,ux,prioritize,facilitate,docs,code-review,triage}
-mkdir -p $BASE/shards/{requirements,architecture,stories}
+mkdir -p $BASE/shards/{requirements,architecture,tasks}
 mkdir -p $BASE/workspace
 ```
 
@@ -186,7 +186,7 @@ Dependencies:
   Update all:      bash <plugin-root>/resources/scripts/update-deps.sh
 
 Available roles:
-  /circle:scope       - Scope Clarifier (requirements, user stories)
+  /circle:scope       - Scope Clarifier (requirements, work items)
   /circle:arch        - Architecture Owner (design, ADRs, trade-offs)
   /circle:impl        - Implementer (implementation, code review)
   /circle:qa          - Quality Guardian (test strategy, QA)

--- a/plugin/skills/prioritize/SKILL.md
+++ b/plugin/skills/prioritize/SKILL.md
@@ -70,9 +70,9 @@ Read from `~/.claude/circle/projects/{project}/output/`:
    |---|---|---|
    | {Goal} | {How to measure} | {Target value} |
 
-   ## User Stories
-   ### Epic 1: {Name}
-   - As a {user}, I want to {action}, so that {benefit}
+   ## Work Items
+   ### Initiative 1: {Name}
+   - Enable {actor} to {action} for {outcome}
      - Acceptance Criteria:
        - [ ] {Criterion}
 

--- a/plugin/skills/qa/SKILL.md
+++ b/plugin/skills/qa/SKILL.md
@@ -278,7 +278,7 @@ Run when invoked with `/circle:qa lint`. Validates internal consistency of the C
       ```markdown
       ## TDD Compliance
 
-      | Story/Unit | Red | Green | Refactor | Verdict |
+      | Task/Unit | Red | Green | Refactor | Verdict |
       |---|---|---|---|---|
       | {description} | ✓ abc1234 | ✓ def5678 | ✓ ghi9012 | PASS |
       | {description} | ✓ jkl3456 | ✗ missing | — | FAIL |
@@ -292,16 +292,16 @@ Run when invoked with `/circle:qa lint`. Validates internal consistency of the C
    Read the PRD (`prioritize/PRD.md`) and architecture (`arch/architecture.md`), then verify against the implemented code:
 
    **A) Scope Drift Detection:**
-   - Map all Must Have user stories from the PRD
+   - Map all Must Have work items from the PRD
    - Scan implemented code for routes, endpoints, services, modules, and configurations
-   - For each implemented component, trace it back to a PRD user story
+   - For each implemented component, trace it back to a PRD work item
    - Produce a traceability table in the test report:
      ```markdown
      ## Scope Drift Analysis
 
-     | Implemented Component | PRD User Story | Status |
+     | Implemented Component | PRD Work Item | Status |
      |---|---|---|
-     | /api/users endpoint | US-1: User registration | Traced |
+     | /api/users endpoint | WI-1: User registration | Traced |
      | /api/analytics endpoint | — | UNTRACED |
      ```
    - Components marked UNTRACED = scope drift → P1

--- a/plugin/skills/scope/SKILL.md
+++ b/plugin/skills/scope/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scope
-description: Scope Clarifier — Gathers requirements, clarifies scope, breaks down user stories. Use to start a new feature or clarify ambiguous requirements.
+description: Scope Clarifier — Gathers requirements, clarifies scope, breaks down work items. Use to start a new feature or clarify ambiguous requirements.
 allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork

--- a/plugin/skills/shard/SKILL.md
+++ b/plugin/skills/shard/SKILL.md
@@ -9,14 +9,14 @@ metadata:
 
 # Circle Document Sharding
 
-Implements Circle context sharding: splits large documents into atomic story files that roles can load individually, dramatically reducing token usage.
+Implements Circle context sharding: splits large documents into atomic task files that roles can load individually, dramatically reducing token usage.
 
 ## Why Sharding Matters
 
-When the Implementer works on STORY-001, it doesn't need to load the entire PRD. Sharding splits documents into focused atomic files so each role invocation loads only what's relevant.
+When the Implementer works on TASK-001, it doesn't need to load the entire PRD. Sharding splits documents into focused atomic files so each role invocation loads only what's relevant.
 
 - **Without sharding**: The Implementer loads full PRD (~5000+ tokens) every time
-- **With sharding**: The Implementer loads one shard (~200-400 tokens) per story
+- **With sharding**: The Implementer loads one shard (~200-400 tokens) per task
 - **Result**: ~90% token reduction per role invocation
 
 ## Input
@@ -37,12 +37,12 @@ If no documents found: "No documents to shard. Run `/circle:prioritize` or `/cir
    ```bash
    PROJECT_NAME=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
    BASE=~/.claude/circle/projects/$PROJECT_NAME
-   mkdir -p $BASE/shards/{requirements,architecture,stories}
+   mkdir -p $BASE/shards/{requirements,architecture,tasks}
    ```
 
 2. **Analyze documents**: Identify independent sections
    - Functional requirements → individual requirement shards
-   - User stories / epics → individual story shards
+   - Work items / initiatives → individual task shards
    - Architecture decisions → individual ADR shards
    - Non-functional requirements → grouped shard
 
@@ -85,17 +85,16 @@ If no documents found: "No documents to shard. Run `/circle:prioritize` or `/cir
    [impact on the system]
    ```
 
-   **Story shards** → `$BASE/shards/stories/`
+   **Task shards** → `$BASE/shards/tasks/`
    ```markdown
-   # STORY-001: Implement User Login
+   # TASK-001: Implement User Login
 
-   **Type**: User Story
+   **Type**: Work Item
    **Priority**: Must Have
-   **Points**: 5
    **Dependencies**: [ADR-001, FR-1.1]
 
-   ## User Story
-   As a user, I want to log in with my credentials, so that I can access my dashboard.
+   ## Description
+   Enable users to log in with credentials to access their dashboard.
 
    ## Acceptance Criteria
    - [ ] User can enter email and password
@@ -114,7 +113,7 @@ If no documents found: "No documents to shard. Run `/circle:prioritize` or `/cir
 4. **Naming convention**: `{TYPE}-{ID}-{slug}.md`
    - `FR-1.1-user-authentication.md`
    - `ADR-001-auth-strategy.md`
-   - `STORY-001-implement-user-login.md`
+   - `TASK-001-implement-user-login.md`
 
 5. **Update session state**:
    ```json
@@ -134,11 +133,11 @@ If no documents found: "No documents to shard. Run `/circle:prioritize` or `/cir
    =================
    Requirements: 8 shards → ~/.claude/circle/projects/{project}/shards/requirements/
    Architecture: 4 shards → ~/.claude/circle/projects/{project}/shards/architecture/
-   Stories:      6 shards → ~/.claude/circle/projects/{project}/shards/stories/
+   Tasks:        6 shards → ~/.claude/circle/projects/{project}/shards/tasks/
 
    Usage:
-   /circle:impl STORY-001    ← Implements only STORY-001
-   /circle:impl STORY-002    ← Implements only STORY-002
+   /circle:impl TASK-001    ← Implements only TASK-001
+   /circle:impl TASK-002    ← Implements only TASK-002
 
    Each invocation loads only the relevant shard (~300 tokens instead of ~5000).
    ```
@@ -146,13 +145,13 @@ If no documents found: "No documents to shard. Run `/circle:prioritize` or `/cir
 ## Post-Sharding Usage
 
 ```bash
-# The Implementer works on only STORY-001
-/circle:impl STORY-001
+# The Implementer works on only TASK-001
+/circle:impl TASK-001
 
 # It will read ONLY:
-# - ~/.claude/circle/projects/{project}/shards/stories/STORY-001.md
+# - ~/.claude/circle/projects/{project}/shards/tasks/TASK-001.md
 # - Any dependencies referenced in the shard (loaded on demand)
-# - NOT: other stories, full PRD, future tasks
+# - NOT: other tasks, full PRD, future work items
 ```
 
 ## Circle Principles

--- a/plugin/skills/tdd/SKILL.md
+++ b/plugin/skills/tdd/SKILL.md
@@ -51,10 +51,10 @@ Stop here. Do NOT proceed without a working test runner.
 ## Input
 
 Accept parameter: `<unit-of-work>` — a description of what to implement. Can be:
-- A user story: "As a user, I want to..."
+- A work item: "Enable users to..."
 - A feature: "Add password validation to the login form"
 - A bugfix: "Fix null pointer when user has no profile"
-- A story shard: `STORY-001` (loaded from `~/.claude/circle/projects/{project}/shards/stories/`)
+- A task shard: `TASK-001` (loaded from `~/.claude/circle/projects/{project}/shards/tasks/`)
 
 If no parameter: ask the user what to implement.
 

--- a/plugin/skills/validate-prd/SKILL.md
+++ b/plugin/skills/validate-prd/SKILL.md
@@ -60,20 +60,20 @@ If PRD is missing after applying the discovery rules above: "PRD not found. Run 
 3. **Run 8 validation checks** in order:
 
    **Check 1 — Completeness**
-   Verify all required PRD sections are present. Required sections (from template): Vision, Goals & Success Metrics, User Stories (with at least one Epic), Prioritization, Release Plan, Dependencies & Risks.
+   Verify all required PRD sections are present. Required sections (from template): Vision, Goals & Success Metrics, Work Items (with at least one Initiative), Prioritization, Release Plan, Dependencies & Risks.
    - PASS: All required sections present with content
    - FAIL: One or more required sections missing or empty
 
    **Check 2 — Requirements Coverage**
-   If `requirements.md` exists, extract all functional requirements (FR-*) and verify each has at least one corresponding user story in the PRD.
-   - PASS: Every FR-* is addressed by a user story
-   - PARTIAL: Some requirements lack user stories (list which)
+   If `requirements.md` exists, extract all functional requirements (FR-*) and verify each has at least one corresponding work item in the PRD.
+   - PASS: Every FR-* is addressed by a work item
+   - PARTIAL: Some requirements lack work items (list which)
    - SKIP: No requirements.md available
 
    **Check 3 — Traceability**
-   Every user story must have acceptance criteria. Each acceptance criterion must be testable — it should contain a verifiable condition, not a vague statement.
-   - PASS: All stories have testable acceptance criteria
-   - FAIL: Stories missing acceptance criteria, or criteria are not testable
+   Every work item must have acceptance criteria. Each acceptance criterion must be testable — it should contain a verifiable condition, not a vague statement.
+   - PASS: All work items have testable acceptance criteria
+   - FAIL: Work items missing acceptance criteria, or criteria are not testable
 
    **Check 4 — Measurability**
    Goals & Success Metrics table must have concrete metrics with target values. "Improve performance" is not measurable; ">0 in first month" is.
@@ -91,7 +91,7 @@ If PRD is missing after applying the discovery rules above: "PRD not found. Run 
    - WARN: Implementation details detected (list locations)
 
    **Check 7 — Domain Compliance**
-   PRD domain (inferred from content) matches the detected project domain. User stories reference appropriate user types.
+   PRD domain (inferred from content) matches the detected project domain. Work items reference appropriate user types.
    - PASS: Domain alignment is consistent
    - WARN: Mismatch detected
 


### PR DESCRIPTION
## Summary
- **BREAKING**: Replace all Agile/Scrum terminology with Holacracy-aligned vocabulary across 19 files
- `STORY-xxx` → `TASK-xxx`, `shards/stories/` → `shards/tasks/`, `user story` → `work item`, `epic` → `initiative`
- PRD template updated: `US-x.x` → `WI-x.x`, purpose-driven format replaces "As a user, I want to..."
- Version bump: 1.2.0 → 1.3.0

## Test plan
- [x] `grep -ri "story\|stories\|epic\|STORY" plugin/` returns 0 matches
- [x] Cross-skill contract verified (shard ↔ impl ↔ greenfield all use `shards/tasks/`)
- [x] PRD template ↔ validate-prd section names aligned
- [x] Version synced across plugin.json, marketplace.json, CHANGELOG
- [x] QA found and fixed 1 stale `US-1` prefix in qa/SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)