### PR TITLE
Rename prioritize skill to refine

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "circle",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "source": "./plugin",
       "description": "18 skills (9 holacracy roles + 9 utilities) with structured workflows, quality gates, self-verification guardrails, anti-overcomplication checks, TDD enforcement, security audits, work tracking, and full customization"
     }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+firebase-debug.log

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -4,7 +4,7 @@ Holacracy-based development workflow plugin for Claude Code with distributed rol
 
 ## Overview
 
-Circle is a pure Markdown plugin for Claude Code that provides a circle of AI roles to help build software — from initial idea through to working code. It ships 18 skills: 9 holacracy roles (Scope Clarifier, Architecture Owner, Implementer, Quality Guardian, Experience Designer, Prioritizer, Facilitator, Security Guardian, Documentation Steward) and 9 utilities (init, greenfield orchestrator, cycle planning, TDD, context sharding, code review, triage, PRD validation, work tracking).
+Circle is a pure Markdown plugin for Claude Code that provides a circle of AI roles to help build software — from initial idea through to working code. It ships 18 skills: 9 holacracy roles (Scope Clarifier, Architecture Owner, Implementer, Quality Guardian, Experience Designer, Refiner, Facilitator, Security Guardian, Documentation Steward) and 9 utilities (init, greenfield orchestrator, cycle planning, TDD, context sharding, code review, triage, PRD validation, work tracking).
 
 Each role has a clear purpose, domain, and accountability following holacracy principles — authority is distributed and roles act within their domain without asking permission. Circle works for product people, designers, analysts, developers, and documentation writers. No programming knowledge is required to get started.
 
@@ -44,7 +44,7 @@ The plugin follows a zero-footprint principle: it never adds files to the user's
 │       ├── greenfield/    — Full workflow orchestrator
 │       ├── impl/          — Implementer
 │       ├── init/          — Project initialization
-│       ├── prioritize/    — Prioritizer
+│       ├── refine/        — Refiner
 │       ├── qa/            — Quality Guardian
 │       ├── scope/         — Scope Clarifier
 │       ├── security/      — Security Guardian

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Circle works for everyone on the team: product people, designers, analysts, deve
 | `/circle:impl` | Implementer | Writes code, reviews implementations |
 | `/circle:qa` | Quality Guardian | Plans testing strategy, validates quality |
 | `/circle:ux` | Experience Designer | Designs user interfaces and user journeys |
-| `/circle:prioritize` | Prioritizer | Prioritizes features, creates product plans (PRDs) |
+| `/circle:refine` | Refiner | Refines requirements into PRDs, prioritizes features |
 | `/circle:facilitate` | Facilitator | Plans cycles, coordinates the team |
 | `/circle:security` | Security Guardian | Audits security, models threats, checks compliance |
 | `/circle:docs` | Documentation Steward | Generates docs from templates |
@@ -40,7 +40,7 @@ These run multi-step workflows, guiding you through each phase with decision poi
 
 | Command | What it does |
 |---|---|
-| `/circle:greenfield` | Runs the full workflow: Scope Clarifier (requirements) → Prioritizer (product plan) → PRD Validator (quality check) → Experience Designer (design) → Architecture Owner (architecture) → Security review → Facilitator (cycle plan) → Implementer (code) → Quality Guardian (tests). You can skip optional steps. |
+| `/circle:greenfield` | Runs the full workflow: Scope Clarifier (requirements) → Refiner (product plan) → PRD Validator (quality check) → Experience Designer (design) → Architecture Owner (architecture) → Security review → Facilitator (cycle plan) → Implementer (code) → Quality Guardian (tests). You can skip optional steps. |
 | `/circle:cycle` | Interactive cycle planning ceremony — 4-step Shape Up process from shaping review to cycle commitment |
 
 > **Shape Up**: Circle uses [Shape Up](https://basecamp.com/shapeup) for work planning — appetite-based sizing (☕ cappuccino, 🥪 sandwich, 🍲 hutspot) instead of story points, and 4-week cycles instead of sprints.
@@ -142,7 +142,7 @@ Not every role needs every file. The config maps knowledge by concern:
 
 | Role | Loads |
 |---|---|
-| Scope Clarifier, Prioritizer | project + domain |
+| Scope Clarifier, Refiner | project + domain |
 | Architecture Owner | project + domain + architecture + integrations |
 | Implementer | project + domain + architecture + build + integrations |
 | Quality Guardian | project + domain + architecture + build |
@@ -177,7 +177,7 @@ Circle never adds files to your project repository. All outputs are stored in a 
 │   ├── qa/           # Test plans, reports
 │   ├── security/     # Security audits
 │   ├── ux/           # UX designs
-│   ├── prioritize/   # PRDs
+│   ├── refine/       # PRDs
 │   ├── facilitate/   # Cycle plans
 │   └── docs/         # Generated docs
 ├── shards/           # Context shards
@@ -196,7 +196,7 @@ Each work role runs in its own isolated context — it starts fresh every time w
 
 Built-in safety checks prevent the workflow from advancing when something isn't right:
 
-- **PRD Validation Gate**: If PRD validation fails, the workflow loops back to the Prioritizer for fixes before architecture begins
+- **PRD Validation Gate**: If PRD validation fails, the workflow loops back to the Refiner for fixes before architecture begins
 - **Security Block**: The greenfield orchestrator won't move to implementation if critical security issues are found
 - **QA Reject Gate**: If the Quality Guardian rejects the implementation, the workflow sends it back to the Implementer for fixes
 - **TDD Compliance**: The Quality Guardian verifies commit history follows the `test(red):` → `feat(green):` → `refactor:` pattern. Hard enforcement blocks merge; soft enforcement warns only
@@ -258,7 +258,7 @@ Drop a `.md` in `plugin/resources/templates/docs/` or `software/`.
 
 ### New Feature
 ```
-Scope Clarifier → Prioritizer → [PRD Validator] → [Experience Designer] → Architecture Owner → [Security] → [Facilitator] → Implementer (with TDD) → Quality Guardian
+Scope Clarifier → Refiner → [PRD Validator] → [Experience Designer] → Architecture Owner → [Security] → [Facilitator] → Implementer (with TDD) → Quality Guardian
 ```
 Steps in brackets are optional.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## v1.5.0 — Rename Prioritizer to Refiner
+
+### Breaking Change
+
+The `prioritize` skill has been renamed to `refine` to avoid naming conflict with the Score plugin's `/score:prioritize` skill. The role name changes from **Prioritizer** to **Refiner**.
+
+- **Command**: `/circle:prioritize` → `/circle:refine`
+- **Skill directory**: `plugin/skills/prioritize/` → `plugin/skills/refine/`
+- **Output directory**: `~/.claude/circle/projects/{project}/output/refine/` (was `prioritize/`)
+- **Session paths**: `sessions/{id}/refine/` (was `sessions/{id}/prioritize/`)
+- **Config key**: `agents.refine` (was `agents.prioritize`)
+
+### Migration
+
+Existing output files in `prioritize/` directories are not auto-migrated. If you have active sessions referencing `prioritize/` paths, manually rename the directories or start a new session.
+
+### Skills Changed
+
+| Skill | Change |
+|-------|--------|
+| `refine` | Renamed from `prioritize` — frontmatter, output paths, config key |
+| `greenfield` | Updated workflow references, session paths, model/effort routing keys |
+| `cycle` | Updated PRD paths and session directory creation |
+| `scope` | Updated handoff suggestion |
+| `validate-prd` | Updated description, input paths, error messages |
+| `arch` | Updated upstream PRD path |
+| `security` | Updated PRD reference |
+| `ux` | Updated PRD reference |
+| `impl` | Updated PRD reference |
+| `qa` | Updated PRD and guardrails references |
+| `shard` | Updated PRD discovery paths |
+| `facilitate` | Updated PRD path and error message |
+| `init` | Updated output directory creation |
+
+### Config & Resources Changed
+
+| File | Change |
+|------|--------|
+| `guardrails.md` | Updated role name and PRD paths |
+| `deps-manifest.yaml` | Updated `used_by` for Linear |
+| `config-example.yaml` | Updated agent key and comment |
+| `circle.md` | Updated dashboard command and artifact listing |
+
+---
+
 ## v1.4.0 — Multi-Session Workflow Tracking
 
 ### Session Registry (schema v2)

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -265,7 +265,7 @@ Circle assigns a default Claude model and effort level to each fork-context role
 | Role | Default Model | Default Effort | Rationale |
 |------|--------------|----------------|-----------|
 | Scope Clarifier | sonnet | medium | Structured requirements gathering |
-| Prioritizer | sonnet | medium | Feature prioritization |
+| Refiner | sonnet | medium | Feature prioritization |
 | Experience Designer | sonnet | medium | UX design patterns |
 | Architecture Owner | opus | high | Deep trade-off reasoning |
 | Security Guardian | opus | high | Adversarial threat modeling |

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -22,7 +22,7 @@ You don't need to be technical to use Circle. If you can type a sentence and pre
 | Role | What it does |
 |------|-------------|
 | **Scope Clarifier** | Helps you define what you're building and why |
-| **Prioritizer** | Prioritizes features and creates a product plan |
+| **Refiner** | Refines requirements into a product plan, prioritizes features |
 | **Experience Designer** | Designs the user experience and interface |
 | **Architecture Owner** | Plans how the software will be structured |
 | **Implementer** | Writes and reviews the actual code |
@@ -52,14 +52,14 @@ That's it. Each role works the same way: type the command, have a conversation, 
 
 ### If you define the product
 
-Start with the Scope Clarifier to gather requirements, then invoke the Prioritizer to create a product requirements document (PRD) and prioritize features:
+Start with the Scope Clarifier to gather requirements, then invoke the Refiner to create a product requirements document (PRD) and prioritize features:
 
 ```
 /circle:scope
 ```
 then
 ```
-/circle:prioritize
+/circle:refine
 ```
 
 ### If you're a Designer
@@ -98,7 +98,7 @@ The greenfield command runs the entire process from start to finish, with you ma
 /circle:greenfield
 ```
 
-This walks through: Scope Clarifier (requirements) → Prioritizer (product plan) → PRD Validator (quality check) → Experience Designer (design) → Architecture Owner (architecture) → Security Guardian (security audit) → Facilitator (cycle planning) → Implementer (simplicity assessment + implementation with TDD) → Quality Guardian (testing + TDD compliance + coherence & scope drift check). You can skip optional steps.
+This walks through: Scope Clarifier (requirements) → Refiner (product plan) → PRD Validator (quality check) → Experience Designer (design) → Architecture Owner (architecture) → Security Guardian (security audit) → Facilitator (cycle planning) → Implementer (simplicity assessment + implementation with TDD) → Quality Guardian (testing + TDD compliance + coherence & scope drift check). You can skip optional steps.
 
 ## Available commands
 
@@ -107,7 +107,7 @@ Every command starts with `/circle:`. Just type it and press Enter.
 | Command | What it does |
 |---------|-------------|
 | `/circle:scope` | Gather requirements and clarify scope |
-| `/circle:prioritize` | Create a product plan and prioritize features |
+| `/circle:refine` | Create a product plan and prioritize features |
 | `/circle:ux` | Design user experience and interface |
 | `/circle:arch` | Plan software architecture |
 | `/circle:impl` | Implement code |
@@ -136,7 +136,7 @@ Each role saves their work in their own subfolder (e.g., `scope/`, `arch/`, `imp
 ## Tips
 
 - **You can invoke any role at any time.** There's no strict order — use whoever makes sense for what you need right now.
-- **Roles access context within a session.** If the Scope Clarifier creates requirements, the Prioritizer can read them when you invoke it to create a product plan.
+- **Roles access context within a session.** If the Scope Clarifier creates requirements, the Refiner can read them when you invoke it to create a product plan.
 - **Make Circle know your project.** Create a Knowledge Pack — a set of Markdown files in `docs/bmad/` that describe your project's domain, architecture, build system, and integrations. Every role automatically loads the relevant files. See the [Customization Guide](CUSTOMIZATION.md) for details.
 - **You can customize how roles behave** per project. See the [Customization Guide](CUSTOMIZATION.md) for details.
 - **All dependencies are optional.** Circle works out of the box. Extra integrations (like Linear for issue tracking) add functionality but aren't required.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "circle",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Holacracy-based development workflow with distributed roles, quality gates, and Shape Up planning",
   "author": {
     "name": "Alessio Roberto",

--- a/plugin/commands/circle.md
+++ b/plugin/commands/circle.md
@@ -39,7 +39,7 @@ Your circle:
   /circle:impl        — Implementer (implementation, code review)
   /circle:qa          — Quality Guardian (testing, quality)
   /circle:ux          — Experience Designer (UI/UX design)
-  /circle:prioritize  — Prioritizer (prioritization, roadmap)
+  /circle:refine      — Refiner (prioritization, roadmap)
   /circle:facilitate  — Facilitator (cycle planning)
   /circle:security    — Security Guardian (audits, threat modeling)
   /circle:docs        — Documentation Steward
@@ -73,7 +73,7 @@ Generated artifacts:
   qa/          <list of files or empty>
   security/    <list of files or empty>
   ux/          <list of files or empty>
-  prioritize/  <list of files or empty>
+  refine/      <list of files or empty>
   facilitate/  <list of files or empty>
   code-review/ <list of files or empty>
   triage/      <list of files or empty>

--- a/plugin/resources/deps-manifest.yaml
+++ b/plugin/resources/deps-manifest.yaml
@@ -19,7 +19,7 @@ groups:
         check_command: ""
         install_command: ""
         install_note: "Enable in Claude Code settings → MCP Servers → Linear"
-        used_by: "scope, arch, impl, qa, ux, prioritize, facilitate, docs, code-review, cycle"
+        used_by: "scope, arch, impl, qa, ux, refine, facilitate, docs, code-review, cycle"
 
       - id: claude-mem
         type: plugin

--- a/plugin/resources/guardrails.md
+++ b/plugin/resources/guardrails.md
@@ -13,11 +13,11 @@ Before handoff, verify your output covers upstream requirements. This closes the
 
 | Your Role | Read This | Check For |
 |---|---|---|
-| arch | `scope/requirements.md` or `prioritize/PRD.md` | Each FR-*/work item addressed in architecture |
+| arch | `scope/requirements.md` or `refine/PRD.md` | Each FR-*/work item addressed in architecture |
 | impl | `arch/architecture.md` | Each component/module implemented |
-| qa | `scope/requirements.md` or `prioritize/PRD.md` | Each acceptance criterion has a test |
-| prioritize | `scope/requirements.md` | Each FR-* has a work item |
-| ux | `prioritize/PRD.md` | Each work item has UX coverage |
+| qa | `scope/requirements.md` or `refine/PRD.md` | Each acceptance criterion has a test |
+| refine | `scope/requirements.md` | Each FR-* has a work item |
+| ux | `refine/PRD.md` | Each work item has UX coverage |
 | security | `arch/architecture.md` | Each component has threat analysis |
 
 Read the upstream artifact from `~/.claude/circle/projects/{project}/output/`. If the first path doesn't exist, try the alternative (e.g., PRD.md if requirements.md is missing).

--- a/plugin/resources/templates/config-example.yaml
+++ b/plugin/resources/templates/config-example.yaml
@@ -18,7 +18,7 @@
 greenfield_defaults:
   ux: true
   facilitate: false
-  validate_prd: true     # PRD quality validation after prioritize (default: true since v0.8.0)
+  validate_prd: true     # PRD quality validation after refine (default: true since v0.8.0)
 
 # Guardrails — self-verification before handoff
 # Roles verify their output covers upstream requirements before completing.
@@ -49,7 +49,7 @@ agents:
   scope:
     model: sonnet
     effort: medium
-  prioritize:
+  refine:
     model: sonnet
     effort: medium
   arch:

--- a/plugin/skills/arch/SKILL.md
+++ b/plugin/skills/arch/SKILL.md
@@ -40,13 +40,13 @@ Detect the project domain by analyzing files in the current directory:
 
 Read requirements from `~/.claude/circle/projects/{project}/output/`:
 - Check for: `scope/requirements.md`
-- Also check: `prioritize/PRD.md` (if Prioritizer has refined requirements)
+- Also check: `refine/PRD.md` (if Refiner has refined requirements)
 - If none found: "Requirements missing. Run `/circle:scope` first to gather requirements."
 
 Also check for project config: `~/.claude/circle/projects/{project}/config.yaml`
 - If `extra_instructions` for arch exists, incorporate them
 - If `context_files` defined, read those files for additional architectural context
-- **Upstream for self-verification**: `scope/requirements.md` or `prioritize/PRD.md` (loaded before handoff if guardrails enabled)
+- **Upstream for self-verification**: `scope/requirements.md` or `refine/PRD.md` (loaded before handoff if guardrails enabled)
 
 ## Domain-Specific Behavior
 
@@ -105,7 +105,7 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
 
 6. **Generate architecture document**: Write to `~/.claude/circle/projects/$PROJECT_NAME/output/arch/{filename}`
 
-7. **Self-Verification**: Read and follow the self-verification protocol in `${CLAUDE_PLUGIN_ROOT}/resources/guardrails.md`. Upstream artifact: `scope/requirements.md` or `prioritize/PRD.md`.
+7. **Self-Verification**: Read and follow the self-verification protocol in `${CLAUDE_PLUGIN_ROOT}/resources/guardrails.md`. Upstream artifact: `scope/requirements.md` or `refine/PRD.md`.
 
 8. **MCP Integration** (if available):
    - **Domain-specific tools**: If domain-specific MCP tools are available (configured via deps-manifest.yaml), use them to look up framework documentation and platform best practices.

--- a/plugin/skills/cycle/SKILL.md
+++ b/plugin/skills/cycle/SKILL.md
@@ -31,11 +31,11 @@ shaping_review → appetite_sizing → cycle_commitment → quality_notes
 ## Prerequisites
 
 Read from `~/.claude/circle/projects/{project}/output/`:
-- PRD: `sessions/*/prioritize/PRD-*.md` (session-scoped, preferred). Fallback: `prioritize/PRD-*.md` (legacy).
+- PRD: `sessions/*/refine/PRD-*.md` (session-scoped, preferred). Fallback: `refine/PRD-*.md` (legacy).
 - Requirements: `sessions/*/scope/requirements*.md` (session-scoped, preferred). Fallback: `scope/requirements*.md` (legacy).
 - Previous cycle: `facilitate/cycle-plan-*.md`
 
-If no PRD found: "No PRD or pitch found. Run `/circle:prioritize` to create one, or describe your ideas directly."
+If no PRD found: "No PRD or pitch found. Run `/circle:refine` to create one, or describe your ideas directly."
 
 ## State Management
 
@@ -59,7 +59,7 @@ Link a Linear issue? (paste ID like ENG-42, or press Enter to auto-generate)
 **Create session artifact directory**:
 ```bash
 SESSION_ID="{the chosen session ID}"
-mkdir -p $BASE/output/sessions/$SESSION_ID/{facilitate,scope,prioritize}
+mkdir -p $BASE/output/sessions/$SESSION_ID/{facilitate,scope,refine}
 ```
 
 **Check existing cycle sessions** (on startup):

--- a/plugin/skills/facilitate/SKILL.md
+++ b/plugin/skills/facilitate/SKILL.md
@@ -39,11 +39,11 @@ Detect the project domain by analyzing files in the current directory:
 ## Input Prerequisites
 
 Read from `~/.claude/circle/projects/{project}/output/`:
-- PRD: `prioritize/PRD-*.md`
+- PRD: `refine/PRD-*.md`
 - Architecture: `arch/architecture.md`
 - Optional: `qa/test-plan-*.md`
 - Previous cycle: `facilitate/cycle-plan-*.md`
-- If PRD missing: "PRD or pitch needed for cycle planning. Run `/circle:prioritize` first."
+- If PRD missing: "PRD or pitch needed for cycle planning. Run `/circle:refine` first."
 
 ## Process
 

--- a/plugin/skills/greenfield/SKILL.md
+++ b/plugin/skills/greenfield/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: greenfield
-description: Orchestrates full greenfield workflow (init → Scope Clarifier → Prioritizer → PRD Validator → Experience Designer → Architecture Owner → Security → Facilitator → Implementer → Quality Guardian). Interactive with human checkpoints at each phase. Optional phases (PRD Validator, Experience Designer, Facilitator). Resumable from any checkpoint.
+description: Orchestrates full greenfield workflow (init → Scope Clarifier → Refiner → PRD Validator → Experience Designer → Architecture Owner → Security → Facilitator → Implementer → Quality Guardian). Interactive with human checkpoints at each phase. Optional phases (PRD Validator, Experience Designer, Facilitator). Resumable from any checkpoint.
 allowed-tools: Read, Write, Grep, Glob, Bash
 metadata:
   context: same
@@ -20,19 +20,19 @@ You are the conductor — you don't play the instruments, you ensure the orchest
 
 **Base Workflow** (7 mandatory steps):
 ```
-init → scope → prioritize → arch → security → impl → qa
+init → scope → refine → arch → security → impl → qa
 ```
 
 **Optional Phases** (3 optional steps):
 ```
-+ validate-prd (after prioritize, before arch)
-+ ux (after prioritize, before arch)
++ validate-prd (after refine, before arch)
++ ux (after refine, before arch)
 + facilitate (before impl)
 ```
 
 **Full Workflow** (10 steps with all options):
 ```
-init → scope → prioritize → validate-prd → ux → arch → security → facilitate → impl → qa
+init → scope → refine → validate-prd → ux → arch → security → facilitate → impl → qa
 ```
 
 ## Commands
@@ -54,7 +54,7 @@ Each role runs with a recommended Claude model and effort level. The orchestrato
 | Role | Default Model | Default Effort | Rationale |
 |------|--------------|----------------|-----------|
 | Scope Clarifier | sonnet | medium | Structured requirements gathering |
-| Prioritizer | sonnet | medium | Feature prioritization |
+| Refiner | sonnet | medium | Feature prioritization |
 | Experience Designer | sonnet | medium | UX design patterns |
 | Architecture Owner | opus | high | Deep trade-off reasoning |
 | Security Guardian | opus | high | Adversarial threat modeling |
@@ -130,7 +130,7 @@ Link a Linear issue? (paste ID like ENG-42, or press Enter to auto-generate)
 **Create session artifact directory**:
 ```bash
 SESSION_ID="{the chosen session ID}"
-mkdir -p $BASE/output/sessions/$SESSION_ID/{scope,arch,impl,qa,security,ux,prioritize,facilitate,docs}
+mkdir -p $BASE/output/sessions/$SESSION_ID/{scope,arch,impl,qa,security,ux,refine,facilitate,docs}
 mkdir -p $BASE/shards/sessions/$SESSION_ID/{requirements,architecture,stories}
 ```
 
@@ -173,7 +173,7 @@ Optional phases:
       },
       "model_routing": {
         "scope": "sonnet",
-        "prioritize": "sonnet",
+        "refine": "sonnet",
         "validate-prd": "sonnet",
         "ux": "sonnet",
         "arch": "opus",
@@ -184,7 +184,7 @@ Optional phases:
       },
       "effort_routing": {
         "scope": "medium",
-        "prioritize": "medium",
+        "refine": "medium",
         "validate-prd": "low",
         "ux": "medium",
         "arch": "high",
@@ -193,7 +193,7 @@ Optional phases:
         "impl": "high",
         "qa": "medium"
       },
-      "step_sequence": ["init", "scope", "prioritize", ...],
+      "step_sequence": ["init", "scope", "refine", ...],
       "artifacts": [],
       "sharding": {},
       "checkpoints": [
@@ -247,7 +247,7 @@ All output paths below are relative to `sessions/{SESSION_ID}/`:
 | Step | Role | Model | Effort | Purpose | Input | Output |
 |---|---|---|---|---|---|---|
 | 1 | **Scope Clarifier** | sonnet | medium | Gather requirements | User description | `scope/requirements.md` |
-| 2 | **Prioritizer** | sonnet | medium | Prioritize & create PRD | Requirements | `prioritize/PRD-{date}.md` |
+| 2 | **Refiner** | sonnet | medium | Prioritize & create PRD | Requirements | `refine/PRD-{date}.md` |
 | 3* | **PRD Validator** | sonnet | low | Validate PRD quality | PRD + Requirements | `qa/prd-validation-report.md` |
 | 4* | **Experience Designer** | sonnet | medium | Design UX | PRD | `ux/ux-design.md` |
 | 5 | **Architecture Owner** | opus | high | Design architecture | PRD + UX (if available) | `arch/architecture.md` |
@@ -337,7 +337,7 @@ Progress: [{completed}/{total}]
 Completed:
   ✓ init
   ✓ scope → sessions/{SESSION_ID}/scope/requirements.md
-  ✓ prioritize → sessions/{SESSION_ID}/prioritize/PRD.md
+  ✓ refine → sessions/{SESSION_ID}/refine/PRD.md
   → arch (current)
   ○ impl
   ○ qa
@@ -360,9 +360,9 @@ After the validate-prd step:
 
    Review: ~/.claude/circle/projects/{project}/output/sessions/{SESSION_ID}/qa/prd-validation-report.md
 
-   Fix the issues with /circle:prioritize, then re-run /circle:validate-prd.
+   Fix the issues with /circle:refine, then re-run /circle:validate-prd.
    ```
-4. Update `sessions[SESSION_ID]` with `current_step: "prioritize"` and add a checkpoint entry, then loop back to the prioritize step
+4. Update `sessions[SESSION_ID]` with `current_step: "refine"` and add a checkpoint entry, then loop back to the refine step
 5. If PASS or PASS with notes: advance to next step (ux or arch)
 
 ### Gate 1: Security P0 Block
@@ -422,7 +422,7 @@ When all steps are completed:
    | Phase | Role | Status | Artifact |
    |---|---|---|---|
    | Requirements | Scope Clarifier | ✓ | requirements.md |
-   | PRD | Prioritizer | ✓ | PRD.md |
+   | PRD | Refiner | ✓ | PRD.md |
    | PRD Validation | PRD Validator | ✓/skipped | prd-validation-report.md |
    | UX Design | Experience Designer | ✓/skipped | ux-design.md |
    | Architecture | Architecture Owner | ✓ | architecture.md |
@@ -465,7 +465,7 @@ When all steps are completed:
 
 ## Context Sharding Integration
 
-After the Prioritizer's PRD phase, if the PRD exceeds ~3000 tokens:
+After the Refiner's PRD phase, if the PRD exceeds ~3000 tokens:
 
 ```
 The PRD is quite large ({token_estimate} tokens).

--- a/plugin/skills/impl/SKILL.md
+++ b/plugin/skills/impl/SKILL.md
@@ -40,7 +40,7 @@ Detect the project domain by analyzing files in the current directory:
 
 Read design from `~/.claude/circle/projects/{project}/output/`:
 - Check for: `arch/architecture.md`
-- Also useful: `scope/requirements.md`, `prioritize/PRD.md`
+- Also useful: `scope/requirements.md`, `refine/PRD.md`
 - If architecture missing: "Design missing. Run `/circle:arch` first."
 
 Also check for project config: `~/.claude/circle/projects/{project}/config.yaml`
@@ -86,7 +86,7 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
 
 3. **Simplicity Assessment**: Before writing any code, evaluate the design for overcomplication:
 
-   Read the architecture (`arch/architecture.md`) and PRD (`prioritize/PRD.md`), then assess:
+   Read the architecture (`arch/architecture.md`) and PRD (`refine/PRD.md`), then assess:
 
    **a) Scope check**: Does the design contain components, services, or modules not directly required by Must Have work items? If yes, list them and ask the user:
    > "These components are in the architecture but not traced to MVP work items: {list}. Proceed with full design, or simplify?"

--- a/plugin/skills/init/SKILL.md
+++ b/plugin/skills/init/SKILL.md
@@ -137,7 +137,7 @@ Zero footprint — all in home directory:
 PROJECT_NAME=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
 BASE=~/.claude/circle/projects/$PROJECT_NAME
 
-mkdir -p $BASE/output/{scope,arch,impl,qa,security,ux,prioritize,facilitate,docs,code-review,triage}
+mkdir -p $BASE/output/{scope,arch,impl,qa,security,ux,refine,facilitate,docs,code-review,triage}
 mkdir -p $BASE/output/sessions
 mkdir -p $BASE/shards/{requirements,architecture,tasks}
 mkdir -p $BASE/shards/sessions
@@ -208,7 +208,7 @@ Available roles:
   /circle:impl        - Implementer (implementation, code review)
   /circle:qa          - Quality Guardian (test strategy, QA)
   /circle:ux          - Experience Designer (UI/UX design)
-  /circle:prioritize  - Prioritizer (prioritization, roadmap)
+  /circle:refine      - Refiner (prioritization, roadmap)
   /circle:facilitate  - Facilitator (cycle planning, coordination)
   /circle:security    - Security Guardian (audits, threat modeling)
   /circle:docs        - Documentation Steward (doc generation)

--- a/plugin/skills/qa/SKILL.md
+++ b/plugin/skills/qa/SKILL.md
@@ -39,11 +39,11 @@ Detect the project domain by analyzing files in the current directory:
 ## Input Prerequisites
 
 Read from `~/.claude/circle/projects/{project}/output/`:
-- Requirements: `scope/requirements.md` or `prioritize/PRD.md`
+- Requirements: `scope/requirements.md` or `refine/PRD.md`
 - Architecture: `arch/architecture.md`
 - Implementation notes: `impl/implementation-notes-*.md`
 - If requirements missing: "Requirements needed for test planning. Run `/circle:scope` first."
-- **Upstream for self-verification**: `scope/requirements.md` or `prioritize/PRD.md` (loaded before handoff if guardrails enabled)
+- **Upstream for self-verification**: `scope/requirements.md` or `refine/PRD.md` (loaded before handoff if guardrails enabled)
 
 ## Domain-Specific Behavior
 
@@ -289,7 +289,7 @@ Run when invoked with `/circle:qa lint`. Validates internal consistency of the C
 
 6. **Coherence & Scope Drift Check**:
 
-   Read the PRD (`prioritize/PRD.md`) and architecture (`arch/architecture.md`), then verify against the implemented code:
+   Read the PRD (`refine/PRD.md`) and architecture (`arch/architecture.md`), then verify against the implemented code:
 
    **A) Scope Drift Detection:**
    - Map all Must Have work items from the PRD
@@ -328,7 +328,7 @@ Run when invoked with `/circle:qa lint`. Validates internal consistency of the C
    - Missing declared integration point → P1
    - Circular dependency → P0
 
-7. **Self-Verification**: Read and follow the self-verification protocol in `${CLAUDE_PLUGIN_ROOT}/resources/guardrails.md`. Upstream artifact: `scope/requirements.md` or `prioritize/PRD.md`.
+7. **Self-Verification**: Read and follow the self-verification protocol in `${CLAUDE_PLUGIN_ROOT}/resources/guardrails.md`. Upstream artifact: `scope/requirements.md` or `refine/PRD.md`.
 
 8. **Save** to `~/.claude/circle/projects/$PROJECT_NAME/output/qa/test-report-{date}.md`
 

--- a/plugin/skills/refine/SKILL.md
+++ b/plugin/skills/refine/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: prioritize
-description: Prioritizer — Prioritizes features, creates PRDs, manages roadmap. Use after initial requirements to refine and prioritize.
+name: refine
+description: Refiner — Refines requirements into PRDs, prioritizes features, manages roadmap. Use after initial requirements to refine and prioritize.
 allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
@@ -9,9 +9,9 @@ metadata:
   effort: medium
 ---
 
-# Prioritizer
+# Refiner
 
-You energize the **Prioritizer** role in the Circle. You translate business needs into actionable product requirements and make prioritization decisions.
+You energize the **Refiner** role in the Circle. You translate business needs into actionable product requirements and make prioritization decisions.
 
 ## Soul
 
@@ -21,7 +21,7 @@ Key reminders: Impact over activity. Say no to scope creep. Data over opinions.
 ## Model
 
 **Default model**: sonnet
-**Override**: Set `agents.prioritize.model` in project `config.yaml`.
+**Override**: Set `agents.refine.model` in project `config.yaml`.
 **Rationale**: Feature prioritization is structured decision-making that does not require deep reasoning.
 
 > When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
@@ -47,7 +47,7 @@ Read from `~/.claude/circle/projects/{project}/output/`:
 1. **Initialize output directory**:
    ```bash
    PROJECT_NAME=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
-   mkdir -p ~/.claude/circle/projects/$PROJECT_NAME/output/prioritize
+   mkdir -p ~/.claude/circle/projects/$PROJECT_NAME/output/refine
    ```
 
 2. **Analyze requirements**: Review the Scope Clarifier's output and understand the full scope
@@ -94,7 +94,7 @@ Read from `~/.claude/circle/projects/{project}/output/`:
    {Known dependencies and risk mitigation}
    ```
 
-5. **Save** to `~/.claude/circle/projects/$PROJECT_NAME/output/prioritize/PRD-{date}.md`
+5. **Save** to `~/.claude/circle/projects/$PROJECT_NAME/output/refine/PRD-{date}.md`
 
 6. **MCP Integration** (if available):
    - **Linear**: Create issues from pitches, set priorities. Full access to issue management.
@@ -103,8 +103,8 @@ Read from `~/.claude/circle/projects/{project}/output/`:
 7. **Work Summary**: Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
 
 8. **Handoff**:
-   > **Prioritizer — Complete.**
-   > Output saved to: `~/.claude/circle/projects/{project}/output/prioritize/PRD-{date}.md`
+   > **Refiner — Complete.**
+   > Output saved to: `~/.claude/circle/projects/{project}/output/refine/PRD-{date}.md`
    > Pitches: {count}, Must Have: {count}, Should Have: {count}
    > Next suggested role: `/circle:arch` for architecture design, or `/circle:ux` for UX design.
 

--- a/plugin/skills/scope/SKILL.md
+++ b/plugin/skills/scope/SKILL.md
@@ -103,7 +103,7 @@ Detect the project domain by analyzing files in the current directory:
 8. **Handoff**:
    > **Scope Clarifier — Complete.**
    > Output saved to: `~/.claude/circle/projects/{project}/output/scope/{filename}`
-   > Next suggested role: `/circle:prioritize` for product prioritization, or `/circle:arch` for architecture design.
+   > Next suggested role: `/circle:refine` for product prioritization, or `/circle:arch` for architecture design.
 
 ## Circle Principles
 - Human-in-the-loop: ask questions, don't assume

--- a/plugin/skills/security/SKILL.md
+++ b/plugin/skills/security/SKILL.md
@@ -40,7 +40,7 @@ Detect the project domain by analyzing files in the current directory:
 
 Read from `~/.claude/circle/projects/{project}/output/`:
 - Architecture: `arch/architecture.md`
-- Also useful: `scope/requirements.md`, `prioritize/PRD.md`
+- Also useful: `scope/requirements.md`, `refine/PRD.md`
 - If architecture missing: "Architecture missing. Run `/circle:arch` first."
 
 Also check for project config: `~/.claude/circle/projects/{project}/config.yaml`

--- a/plugin/skills/shard/SKILL.md
+++ b/plugin/skills/shard/SKILL.md
@@ -27,11 +27,11 @@ Automatically detect documents to shard in `~/.claude/circle/projects/{project}/
 
 | Source | Session-scoped path | Legacy path (standalone) |
 |---|---|---|
-| PRD | `sessions/{SESSION_ID}/prioritize/PRD-*.md` | `prioritize/PRD-*.md` |
+| PRD | `sessions/{SESSION_ID}/refine/PRD-*.md` | `refine/PRD-*.md` |
 | Architecture | `sessions/{SESSION_ID}/arch/architecture.md` | `arch/architecture.md` |
 | Requirements | `sessions/{SESSION_ID}/scope/requirements.md` | `scope/requirements.md` |
 
-If no documents found in either location: "No documents to shard. Run `/circle:prioritize` or `/circle:scope` first."
+If no documents found in either location: "No documents to shard. Run `/circle:refine` or `/circle:scope` first."
 
 ## Process
 
@@ -139,7 +139,7 @@ If no documents found in either location: "No documents to shard. Run `/circle:p
            "enabled": true,
            "shards_count": 15,
            "last_shard_date": "{ISO-8601}",
-           "sources": ["prioritize/PRD.md", "arch/architecture.md"]
+           "sources": ["refine/PRD.md", "arch/architecture.md"]
          }
        }
      }
@@ -153,7 +153,7 @@ If no documents found in either location: "No documents to shard. Run `/circle:p
        "enabled": true,
        "shards_count": 15,
        "last_shard_date": "{ISO-8601}",
-       "sources": ["prioritize/PRD.md", "arch/architecture.md"]
+       "sources": ["refine/PRD.md", "arch/architecture.md"]
      }
    }
    ```

--- a/plugin/skills/ux/SKILL.md
+++ b/plugin/skills/ux/SKILL.md
@@ -39,7 +39,7 @@ Detect the project domain by analyzing files in the current directory:
 ## Input Prerequisites
 
 Read from `~/.claude/circle/projects/{project}/output/`:
-- Requirements: `scope/requirements.md` or `prioritize/PRD.md`
+- Requirements: `scope/requirements.md` or `refine/PRD.md`
 - If requirements missing: "Requirements needed for UX design. Run `/circle:scope` first."
 
 ## Domain-Specific Behavior

--- a/plugin/skills/validate-prd/SKILL.md
+++ b/plugin/skills/validate-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validate-prd
-description: "PRD Validator — Validates PRD quality against 8 structured checks adapted from Circle-METHOD. Use after prioritize, before arch."
+description: "PRD Validator — Validates PRD quality against 8 structured checks adapted from Circle-METHOD. Use after refine, before arch."
 allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
@@ -39,13 +39,13 @@ Detect the project domain by analyzing files in the current directory:
 ## Input Prerequisites
 
 Read from `~/.claude/circle/projects/{project}/output/`:
-- **Required**: resolve the PRD from `prioritize/` as follows:
+- **Required**: resolve the PRD from `refine/` as follows:
   - If `$ARGUMENTS` is **not** provided: select the most recent `PRD-*.md` file (by modification time). If none exist, fall back to `PRD.md` if present.
-  - If `$ARGUMENTS` **is** provided: use only its basename component as the PRD filename (strip any path separators and `..` segments). Do not allow path traversal — only filenames under `prioritize/` are allowed.
+  - If `$ARGUMENTS` **is** provided: use only its basename component as the PRD filename (strip any path separators and `..` segments). Do not allow path traversal — only filenames under `refine/` are allowed.
 - **Optional**: `scope/requirements.md` — enables requirements coverage check
 - **Reference**: `${CLAUDE_PLUGIN_ROOT}/resources/templates/software/PRD.md` — template for completeness check
 
-If PRD is missing after applying the discovery rules above: "PRD not found. Run `/circle:prioritize` first to create a PRD."
+If PRD is missing after applying the discovery rules above: "PRD not found. Run `/circle:refine` first to create a PRD."
 
 ## Process
 
@@ -143,7 +143,7 @@ If PRD is missing after applying the discovery rules above: "PRD not found. Run 
    **If NEEDS REVISION:**
    > **PRD Validator — NEEDS REVISION.**
    > Output saved to: `~/.claude/circle/projects/{project}/output/qa/prd-validation-report.md`
-   > {count} blocker(s) found. Fix and re-run `/circle:validate-prd`, or revise with `/circle:prioritize`.
+   > {count} blocker(s) found. Fix and re-run `/circle:validate-prd`, or revise with `/circle:refine`.
 
    **If PASS with notes:**
    > **PRD Validator — PASS with notes.**


### PR DESCRIPTION
## Summary
- Renames `/circle:prioritize` to `/circle:refine` to avoid naming conflict with `/score:prioritize` from the Score plugin
- Updates 24 files: skill directory, 10 cross-referencing skills, 2 orchestrators, config files, docs
- Adds `.gitignore` for `firebase-debug.log` (generated by Firebase MCP server)
- Bumps version to v1.5.0

## Test plan
- [ ] Verify `/circle:refine` loads correctly and produces PRD output
- [ ] Verify `/circle:greenfield` workflow references refine in step sequence
- [ ] Verify no remaining `prioritize` references in plugin source (excluding historical docs/plans)

🤖 Generated with [Claude Code](https://claude.com/claude-code)