### PR TITLE
feat: add skills-discovery skill with security-gated install flow

### DIFF
--- a/plugin/resources/skill-security-criteria.md
+++ b/plugin/resources/skill-security-criteria.md
@@ -1,0 +1,113 @@
+# Skill Security Criteria
+
+This document defines the security criteria for reviewing external skills before installation. Read this during the security review phase of `/circle:skills-discovery`.
+
+## Risk Classification
+
+### PASS (Low Risk)
+The skill is safe to install. It only reads information and does not modify files or execute commands.
+
+**Allowed tools**:
+- `Read`, `Grep`, `Glob` — read-only file access
+- `WebSearch` — search queries (no data sent)
+
+**Characteristics**:
+- No shell commands
+- No file modifications
+- No external network calls beyond documented APIs
+- No access to sensitive files
+
+### WARN (Medium Risk)
+The skill modifies files or communicates externally. Review carefully before approving.
+
+**Flagged tools**:
+- `Write`, `Edit` — modifies files in the project
+- `WebFetch` — external HTTP communication
+- `Bash` with non-destructive commands (`ls`, `git status`, `npm test`, `npx`, `cat`)
+- `NotebookEdit` — modifies Jupyter notebooks
+
+**Characteristics**:
+- File modifications are scoped to project directory
+- Network calls are to documented, well-known APIs
+- Shell commands are read-only or standard dev tools
+
+### BLOCK (High Risk)
+The skill poses a security threat. Do NOT install.
+
+**Blocked patterns**:
+- `Bash` with destructive commands: `rm -rf`, `rm -f` on paths outside project
+- `Bash` with code execution from network: `curl | sh`, `curl | bash`, `wget | sh`
+- `Bash` with dynamic evaluation: `eval`, `exec`, `source` with untrusted input
+- Access to sensitive files: `.env`, `credentials`, `secrets`, `tokens`, API keys, SSH keys
+- Access to system paths: `~/.ssh/`, `~/.aws/`, `~/.config/`, `/etc/`, `/usr/`
+- Environment variable reading for secrets: `$API_KEY`, `$SECRET`, `$TOKEN`, `$PASSWORD`
+- `dangerouslyDisableSandbox: true` or equivalent bypass flags
+- Obfuscated code: base64-encoded commands, encoded URLs, hex-encoded strings
+- Data exfiltration: `curl -X POST`, `wget --post-data`, outbound `nc`/`netcat`
+
+## Detailed Patterns to Flag
+
+### Shell Command Analysis
+When a skill uses `Bash`, inspect each command for:
+
+| Pattern | Risk | Verdict |
+|---------|------|---------|
+| `rm -rf /` or `rm -rf ~` | Destructive | BLOCK |
+| `rm -rf` on project-scoped paths | Caution | WARN |
+| `curl \| sh` or `curl \| bash` | Remote code execution | BLOCK |
+| `eval "$variable"` | Code injection | BLOCK |
+| `git push --force` | Destructive | WARN |
+| `npm install`, `npx` | Dependency install | WARN |
+| `git status`, `git diff` | Read-only | PASS |
+| `ls`, `cat`, `head` | Read-only | PASS |
+
+### File Access Analysis
+When a skill reads or writes files, check paths for:
+
+| Path Pattern | Risk | Verdict |
+|--------------|------|---------|
+| `.env`, `.env.*` | Secrets exposure | BLOCK |
+| `*credentials*`, `*secret*` | Secrets exposure | BLOCK |
+| `~/.ssh/*`, `~/.aws/*` | System credentials | BLOCK |
+| `~/.config/*` | System config | WARN |
+| Project-scoped paths | Normal | PASS |
+
+### Network Analysis
+When a skill uses `WebFetch` or `Bash` with network commands:
+
+| Pattern | Risk | Verdict |
+|---------|------|---------|
+| `WebFetch` to documented API | External comm | WARN |
+| `curl` GET to known API | External comm | WARN |
+| `curl -X POST` with project data | Data exfiltration | BLOCK |
+| `nc`/`netcat` outbound | Data exfiltration | BLOCK |
+
+## Security Report Format
+
+After analysis, generate a report in this format:
+
+```
+SKILL SECURITY REPORT
+=====================
+Skill: <owner/repo>
+Verdict: PASS | WARN | BLOCK
+
+Risk Level: Low | Medium | High
+Tools Used: [list of tools declared or detected]
+Shell Commands: [list of Bash commands found]
+Files Accessed: [list of file paths referenced]
+Network Calls: [list of URLs or endpoints]
+
+Findings:
+- [Finding 1 with severity]
+- [Finding 2 with severity]
+
+Recommendation: [Install / Review carefully / Do NOT install]
+```
+
+## Verdict Rules
+
+1. If ANY BLOCK pattern is found → verdict is **BLOCK**
+2. If WARN patterns found but no BLOCK → verdict is **WARN**
+3. If only PASS patterns found → verdict is **PASS**
+4. If unable to analyze (repo not accessible) → verdict is **WARN** (caution)

--- a/plugin/skills/skills-discovery/SKILL.md
+++ b/plugin/skills/skills-discovery/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: skills-discovery
+description: Skills Discovery — Discover, review, and install external skills from the marketplace with a mandatory security gate.
+allowed-tools: Read, Grep, Glob, Bash, WebFetch
+metadata:
+  context: same
+  agent: general-purpose
+---
+
+# Skills Discovery & Secure Installation
+
+You energize the **Skills Discovery** role in the Circle. Your accountability is to help users find, evaluate, and safely install external skills from the skills.sh open ecosystem.
+
+## Soul
+
+Read and embody the principles in `${CLAUDE_PLUGIN_ROOT}/resources/soul.md`.
+Key reminders: Impact over activity — suggest only skills relevant to the current project. Growth over ego — external skills can complement the circle, embrace the ecosystem.
+
+## Model
+
+This skill uses `context: same` and inherits the session model.
+
+## Your Role
+
+You manage the discovery and secure installation of external skills. You never install without a security review. You suggest only what is relevant. You degrade gracefully when tools or network are unavailable.
+
+## Domain Detection
+
+Detect the project domain by analyzing files in the current directory:
+- **software**: if common project markers exist (e.g., `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `*.xcodeproj`, `Makefile`, `CMakeLists.txt`, `Gemfile`, `build.gradle`)
+- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
+- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
+- **general**: default if no indicator found
+
+## Process
+
+### Commands
+
+- `/circle:skills-discovery` — suggest skills based on detected domain
+- `/circle:skills-discovery search <query>` — search skills.sh by keyword
+- `/circle:skills-discovery install <owner/repo>` — security review + install
+- `/circle:skills-discovery list` — show installed external skills
+- `/circle:skills-discovery review <owner/repo>` — security review only (no install)
+
+### Prerequisites Check
+
+Before any operation, verify:
+1. **Node.js available**: run `which npx`. If not found, inform user: "npx not found. Install Node.js to use skills.sh integration." and stop.
+2. **Network available**: if operations fail due to network, inform and stop gracefully.
+
+### Domain-Based Discovery
+
+**Trigger**: `/circle:skills-discovery` (no arguments)
+
+1. **Detect domain** using standard domain detection
+2. **Build search queries** based on domain:
+
+   **Software**: analyze `package.json` (if exists) to detect framework:
+   - React/Next.js → search "react", "nextjs"
+   - Vue/Nuxt → search "vue", "nuxt"
+   - Python → search "python"
+   - Go → search "golang"
+   - Default software → search "testing", "linting", "deployment"
+
+   **Business**: search "strategy", "planning", "okr", "business"
+
+   **Personal**: search "productivity", "habits", "journaling"
+
+   **General**: search "best practices" (top results)
+
+3. **Execute search**: run `npx skills find <query>` for each query
+   - If `npx` fails: fallback to `WebFetch https://skills.sh/` and parse results
+4. **Present results** to user:
+   ```
+   Skills suggested for domain: [software]
+
+   1. skill-name (owner/repo) — description [XXK installs]
+   2. skill-name (owner/repo) — description [XXK installs]
+   3. ...
+
+   Select a skill number to review, or 'done' to exit: _
+   ```
+5. **User selects** → proceed to Security Review (below)
+
+### Keyword Search
+
+**Trigger**: `/circle:skills-discovery search <query>`
+
+1. **Execute search**: run `npx skills find <query>`
+   - If `npx` fails: fallback to `WebFetch https://skills.sh/` and parse results
+2. **Present results** (same format as domain-based discovery)
+3. **User selects** → proceed to Security Review
+
+### Install with Security Gate
+
+**Trigger**: `/circle:skills-discovery install <owner/repo>`
+
+1. **Security Review** (mandatory — cannot be skipped):
+
+   a. **Read security criteria**: load `${CLAUDE_PLUGIN_ROOT}/resources/skill-security-criteria.md`
+
+   b. **Fetch skill content** from GitHub:
+      - Run `gh api repos/<owner>/<repo>/contents/` to list files
+      - Fetch SKILL.md content: `gh api repos/<owner>/<repo>/contents/SKILL.md -q .content | base64 -d`
+      - If `gh` fails: use `WebFetch https://github.com/<owner>/<repo>` as fallback
+
+   c. **Analyze content** against security criteria:
+      - Identify tools used (Read, Write, Bash, WebFetch, etc.)
+      - Scan for shell commands and classify each (PASS/WARN/BLOCK patterns)
+      - Check for file access to sensitive paths
+      - Check for network communication patterns
+      - Check for obfuscated code or encoded commands
+
+   d. **Generate security report** using the format from `skill-security-criteria.md`
+
+   e. **Present report to user**:
+
+      If **BLOCK**:
+      ```
+      SKILL SECURITY REPORT
+      =====================
+      Skill: <owner/repo>
+      Verdict: BLOCK
+
+      [report details]
+
+      This skill poses a security risk and cannot be installed.
+      ```
+      **Stop. Do not proceed with installation.**
+
+      If **WARN**:
+      ```
+      SKILL SECURITY REPORT
+      =====================
+      Skill: <owner/repo>
+      Verdict: WARN
+
+      [report details]
+
+      Install this skill? (y/n): _
+      ```
+
+      If **PASS**:
+      ```
+      SKILL SECURITY REPORT
+      =====================
+      Skill: <owner/repo>
+      Verdict: PASS
+
+      [report details]
+
+      Install this skill? (y/n): _
+      ```
+
+2. **If user approves** (PASS or WARN only):
+   - Run `npx skills add <owner/repo>`
+   - Confirm: "Skill <name> installed successfully."
+
+3. **If user rejects**: "Installation cancelled."
+
+### Review Only
+
+**Trigger**: `/circle:skills-discovery review <owner/repo>`
+
+Same as the Security Review steps above, but **never proceeds to installation**. Useful for inspecting a skill before deciding.
+
+### List Installed
+
+**Trigger**: `/circle:skills-discovery list`
+
+1. Run `npx skills list`
+2. Display results to user
+
+## Error Handling
+
+### npx not available
+```
+npx not found. Node.js is required for skills.sh integration.
+Install Node.js: https://nodejs.org/
+```
+
+### skills.sh unreachable
+```
+Could not reach skills.sh. Check your network connection.
+The Circle workflow continues normally without external skills.
+```
+
+### GitHub repo not accessible
+```
+Could not access <owner/repo> on GitHub.
+The repository may be private or unavailable.
+Verdict: WARN (unable to verify content)
+```
+
+### No results found
+```
+No skills found for "<query>".
+Try a different search term or browse skills.sh directly.
+```
+
+## Circle Principles
+- **Security first**: never install without review — no exceptions
+- **Human-in-the-loop**: user approves every installation
+- **Graceful degradation**: network/tool failures inform, never block the workflow
+- **Impact over activity**: suggest only relevant skills, not everything available
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope
+and no existing Circle role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.


### PR DESCRIPTION
## Summary

- New **skills-discovery** skill for discovering, reviewing, and installing external skills from a marketplace
- Mandatory **security gate** with static analysis rules before any skill installation
- New `skill-security-criteria.md` resource defining the security review checklist

## Context

This is **PR 2 of 4** feature PRs from the fork. Fully independent — no overlap with other PRs.

**Related PRs:**
- PR-A: Governance Protocol (independent)
- PR-C: Multi-Domain Support (independent)
- PR-D: Role Promotion (independent)

## Files changed

| Type | Files |
|------|-------|
| New | `skills-discovery/SKILL.md`, `skill-security-criteria.md` |

Only 2 new files, zero modifications to existing files. No version bumps or changelog entries.

## Test plan

- [ ] Verify `skills-discovery/SKILL.md` frontmatter is valid
- [ ] Verify WebFetch is in allowed-tools
- [ ] Verify security criteria document covers all gates
- [ ] Invoke `/circle:skills-discovery` and confirm it works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)