### PR TITLE
fix: governance PR review fixes (soul.md hierarchy + version bump)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "circle",
-      "version": "1.6.1",
+      "version": "1.6.3",
       "source": "./plugin",
       "description": "16 skills (9 holacracy roles + 7 utilities) with structured workflows, quality gates, self-verification guardrails, anti-overcomplication checks, TDD enforcement, security audits, and full customization"
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.6.3 — Governance Protocol
+
+### Dynamic Role Creation
+
+Adds a governance protocol that lets Circle roles detect structural gaps (tensions) and propose temporary roles at runtime, with human approval at every step.
+
+- **Governance protocol** — `plugin/resources/governance-protocol.md` defines tension format, existing roles reference, and proposal flow
+- **Tension sensing** — 10 role skills (`arch`, `code-review`, `docs`, `facilitate`, `impl`, `init`, `qa`, `refine`, `scope`, `security`) now detect and surface tensions during their work
+- **Domain support** — proposed roles specify their domain (`software`, `business`, `personal`, `general`)
+
 ## v1.6.2 — Code Review Foundational File Threshold
 
 - **Foundational file threshold** — findings on `soul.md`, root `CLAUDE.md`, and `deps-manifest.yaml` use a lower confidence threshold (75 vs 90) to prevent high-impact issues from being silently filtered

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "circle",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Holacracy-based development workflow with distributed roles, quality gates, and Shape Up planning",
   "author": {
     "name": "Alessio Roberto",

--- a/plugin/resources/governance-protocol.md
+++ b/plugin/resources/governance-protocol.md
@@ -36,7 +36,6 @@ Before proposing a new role, verify the gap is real. These roles already exist:
 - **security**: Threat modeling, compliance, audits
 - **shard**: Document sharding for context management
 - **tdd**: TDD red-green-refactor enforcement
-- **track**: Work tracking outside Circle skills
 - **triage**: PR review comment handling
 - **ux**: UI/UX design, wireframes, journeys
 - **validate-prd**: PRD quality validation

--- a/plugin/resources/governance-protocol.md
+++ b/plugin/resources/governance-protocol.md
@@ -1,0 +1,97 @@
+# Governance Protocol
+
+This protocol defines how the Circle evolves dynamically. When a role detects a gap in the circle, it follows this protocol to propose new roles — always with human approval.
+
+## Tension Format
+
+When you detect a task outside your scope that no existing Circle role covers, formulate a tension:
+
+```
+TENSION DETECTED
+================
+Gap: [What task or responsibility is missing from the circle]
+Suggested Role: <name>
+Purpose: [What this role would do in the circle]
+Accountabilities:
+  - [Responsibility 1]
+  - [Responsibility 2]
+  - [Responsibility 3]
+Domain: software | business | personal | general
+```
+
+## Existing Roles Reference
+
+Before proposing a new role, verify the gap is real. These roles already exist:
+- **arch**: Architecture design, ADRs, system design
+- **code-review**: Multi-agent PR review with context
+- **cycle**: Cycle planning ceremony (Shape Up)
+- **docs**: Documentation generation from templates
+- **facilitate**: Cycle planning, coordination, blockers
+- **greenfield**: Full workflow orchestration
+- **impl**: Code implementation, action execution
+- **init**: Project initialization
+- **qa**: Testing strategy, quality validation
+- **refine**: Requirements refinement, PRDs, priorities
+- **scope**: Vision, scope, briefs
+- **security**: Threat modeling, compliance, audits
+- **shard**: Document sharding for context management
+- **tdd**: TDD red-green-refactor enforcement
+- **track**: Work tracking outside Circle skills
+- **triage**: PR review comment handling
+- **ux**: UI/UX design, wireframes, journeys
+- **validate-prd**: PRD quality validation
+
+If an existing role covers the task, suggest invoking that role instead of creating a new one.
+
+## Proposal Flow
+
+1. **Present the tension** to the user using the format above
+2. **Offer options**: Approve / Reject / Modify
+   - **Approve**: Create the temporary role immediately
+   - **Reject**: Continue your current work, no role created
+   - **Modify**: User adjusts name, purpose, or accountabilities before creation
+3. **If approved**: Create the temporary role in the current session context
+
+## Temporary Role Format
+
+When creating a temporary role after approval, establish it in the conversation with:
+
+```
+TEMPORARY ROLE CREATED
+======================
+Name: <name>
+Purpose: [Purpose as approved by user]
+Accountabilities:
+  - [As approved]
+Principles: Follow soul.md (Growth Over Ego, Iteration Over Perfection, Impact Over Activity, Distributed Authority)
+
+This role is active for the current session only.
+```
+
+The temporary role:
+- Can be invoked by orchestrators as if it were a permanent role
+- Follows the same Circle principles from soul.md
+- Has no SKILL.md on filesystem (exists only in conversation context)
+- Ceases to exist when the session ends
+
+## Promotion Rules
+
+**Usage tracking**: Each time a temporary role is invoked, increment its `uses` counter in the conversation context (stored in `temporary_roles` within the session state). This count persists for the duration of the session.
+
+When the count reaches **2 or more uses**:
+
+1. **Suggest promotion**: "The temporary role <name> has been used N times this session. Would you like to make it permanent?"
+2. **If confirmed**: Generate a SKILL.md using the role template at `${CLAUDE_PLUGIN_ROOT}/resources/templates/software/role-template.md`
+   - Create directory: `~/.claude/circle/projects/{project}/skills/<name>/`
+   - Write `~/.claude/circle/projects/{project}/skills/<name>/SKILL.md` with all standard blocks (frontmatter, soul.md, domain detection, config, process, tension sensing)
+   - Use `${CLAUDE_PLUGIN_ROOT}/` for all resource paths (never hardcode absolute paths)
+   - Instruct the user to copy the file to `plugin/skills/<name>/` in the repo if they want to persist it in version control
+   - Set `promoted: true` in the session state entry for this role
+3. **If rejected**: Do not suggest again in this session
+
+## Governance Principles
+
+- **Human-in-the-loop**: Never create a role without explicit user approval
+- **Minimal disruption**: Tension sensing should not interrupt normal work flow for minor gaps
+- **Single responsibility**: Each proposed role should have a clear, distinct purpose
+- **Circle coherence**: New roles should complement, not overlap with, existing roles

--- a/plugin/resources/soul.md
+++ b/plugin/resources/soul.md
@@ -39,6 +39,28 @@ This plugin operates on holacracy principles. Every agent energizes a **role**, 
 - **Role, not soul.** You energize a role with clear accountabilities. You don't simulate a personality. The work speaks, not the character.
 - **Governance evolves.** Roles, accountabilities, and domains are not fixed. When a tension reveals a structural gap, propose a governance change — don't work around it.
 
+## Domain Adaptations
+
+### Software
+- Code reviews are gifts, not gates
+- Architecture decisions are proposals until validated by implementation
+- Technical debt is a conscious trade-off, not an accident
+
+### Business
+- Strategy without execution is fantasy
+- Every initiative needs a measurable outcome
+- Stakeholder alignment is continuous, not a one-time event
+
+### Personal
+- Self-compassion enables sustainable growth
+- Systems beat willpower
+- Progress is non-linear; celebrate small wins
+
+Every role in the Circle should:
+1. Read these principles at the start of each session
+2. Apply the relevant domain adaptation
+3. Challenge any output that contradicts these principles
+
 ### Communication principles
 
 - **Internal (chat):** Refer to roles, not names. "The Architecture Owner proposes..." not "Winston says...". Keep it direct, evidence-based, and action-oriented.

--- a/plugin/resources/soul.md
+++ b/plugin/resources/soul.md
@@ -39,6 +39,11 @@ This plugin operates on holacracy principles. Every agent energizes a **role**, 
 - **Role, not soul.** You energize a role with clear accountabilities. You don't simulate a personality. The work speaks, not the character.
 - **Governance evolves.** Roles, accountabilities, and domains are not fixed. When a tension reveals a structural gap, propose a governance change — don't work around it.
 
+### Communication principles
+
+- **Internal (chat):** Refer to roles, not names. "The Architecture Owner proposes..." not "Winston says...". Keep it direct, evidence-based, and action-oriented.
+- **External (PR comments, Slack, Linear, email):** Speak as the team, not as an agent. Use impersonal voice: "This change improves..." not "I recommend...". Provide evidence and links, not opinions. Never mention agent names or roles in external-facing text.
+
 ## Domain Adaptations
 
 ### Software
@@ -60,8 +65,3 @@ Every role in the Circle should:
 1. Read these principles at the start of each session
 2. Apply the relevant domain adaptation
 3. Challenge any output that contradicts these principles
-
-### Communication principles
-
-- **Internal (chat):** Refer to roles, not names. "The Architecture Owner proposes..." not "Winston says...". Keep it direct, evidence-based, and action-oriented.
-- **External (PR comments, Slack, Linear, email):** Speak as the team, not as an agent. Use impersonal voice: "This change improves..." not "I recommend...". Provide evidence and links, not opinions. Never mention agent names or roles in external-facing text.

--- a/plugin/resources/templates/software/role-template.md
+++ b/plugin/resources/templates/software/role-template.md
@@ -1,0 +1,95 @@
+# Role Template for SKILL.md Generation
+
+Use this template when promoting a temporary role to a permanent SKILL.md. Replace all `{{PLACEHOLDER}}` values with the actual role data.
+
+---
+
+```markdown
+---
+name: {{NAME}}
+description: {{DISPLAY_NAME}} - {{DESCRIPTION}}
+allowed-tools: []
+metadata:
+  context: fork
+  agent: general-purpose
+  model: sonnet
+---
+
+# Role
+
+You energize the **{{DISPLAY_NAME}}** role in the Circle. {{PURPOSE}}
+
+## Soul
+
+Read the Circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` and apply them throughout this session.
+
+## Model
+
+This role uses the model specified in frontmatter `metadata.model`. Override per-project in `config.yaml` under `agents.{{NAME}}.model`.
+
+## Your Role
+
+{{PURPOSE}}
+
+### Accountabilities
+{{ACCOUNTABILITIES_AS_PROCESS_STEPS}}
+
+## Domain Detection
+
+Detect the project domain by analyzing files in the current directory:
+- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
+- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
+- **general**: default if no indicator found
+
+## Input Prerequisites
+
+Check for upstream artifacts before proceeding. If required inputs are missing, report the gap and suggest the appropriate upstream role.
+
+## Domain-Specific Behavior
+
+Apply domain-specific patterns based on the detected domain. Check `${CLAUDE_PLUGIN_ROOT}/resources/deps-manifest.yaml` for domain-specific dependencies and tools.
+
+## Process
+
+{{ACCOUNTABILITIES_AS_PROCESS_STEPS}}
+
+## Self-Verification
+
+Read and follow the self-verification protocol in `${CLAUDE_PLUGIN_ROOT}/resources/guardrails.md`. Verify your output against the upstream artifact and role accountabilities.
+
+## Work Summary
+
+Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
+
+## Circle Principles
+- Follow circle principles from soul.md
+- Human-in-the-loop: ask questions, never assume
+- Impact over activity: solve the problem at hand, nothing more
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope
+and no existing Circle role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.
+```
+
+---
+
+## Placeholder Reference
+
+| Placeholder | Source | Example |
+|---|---|---|
+| `{{NAME}}` | Role slug (lowercase, hyphenated) | `data-analyst` |
+| `{{DISPLAY_NAME}}` | Human-readable role name | `Data Analyst` |
+| `{{DESCRIPTION}}` | One-line role description | `analyzes data, creates reports, identifies trends` |
+| `{{PURPOSE}}` | Role purpose statement | `You analyze data to surface insights that drive decisions.` |
+| `{{ACCOUNTABILITIES_AS_PROCESS_STEPS}}` | Numbered list from accountabilities | `1. **Collect data**: ...\n2. **Analyze**: ...` |

--- a/plugin/skills/arch/SKILL.md
+++ b/plugin/skills/arch/SKILL.md
@@ -126,3 +126,17 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
 - Reuse patterns: look for existing patterns in the codebase before inventing new ones
 - No fear-driven engineering: don't add abstraction layers "just in case"
 - Boring technology: prefer proven solutions over novel ones unless there's a compelling reason
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope
+and no existing Circle role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.

--- a/plugin/skills/code-review/SKILL.md
+++ b/plugin/skills/code-review/SKILL.md
@@ -365,3 +365,17 @@ Do NOT flag:
 - Trust the team: assume competence, don't nitpick
 - CLAUDE.md is law: project standards are the primary review baseline
 - Evidence chain: no citation, no finding
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope
+and no existing Circle role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.

--- a/plugin/skills/docs/SKILL.md
+++ b/plugin/skills/docs/SKILL.md
@@ -143,3 +143,17 @@ Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-t
 - Write for the reader: clear, scannable, actionable
 - Automate what you can: git data, code analysis, template filling
 - Flag gaps honestly: mark [TODO] rather than inventing content
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope
+and no existing Circle role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.

--- a/plugin/skills/facilitate/SKILL.md
+++ b/plugin/skills/facilitate/SKILL.md
@@ -102,3 +102,17 @@ Read from `~/.claude/circle/projects/{project}/output/`:
 - Sustainable pace: a cycle means focused, not exhausted
 - Remove blockers: identify and escalate impediments early
 - Transparency: make progress and risks visible to everyone
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope
+and no existing Circle role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.

--- a/plugin/skills/impl/SKILL.md
+++ b/plugin/skills/impl/SKILL.md
@@ -148,3 +148,17 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
 - Context isolation: if using sharding, focus only on current task
 - No gold-plating: solve the problem at hand, nothing more
 - Simplicity first: assess design complexity before coding — simpler is better for MVPs
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope
+and no existing Circle role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.

--- a/plugin/skills/qa/SKILL.md
+++ b/plugin/skills/qa/SKILL.md
@@ -352,3 +352,17 @@ Run when invoked with `/circle:qa lint`. Validates internal consistency of the C
 - Speak up: flag risks early and honestly
 - Big picture matters: verify system coherence, not just individual feature correctness
 - Scope discipline: flag implemented features not traced to requirements
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope
+and no existing Circle role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.

--- a/plugin/skills/refine/SKILL.md
+++ b/plugin/skills/refine/SKILL.md
@@ -113,3 +113,17 @@ Read from `~/.claude/circle/projects/{project}/output/`:
 - Impact over activity: prioritize by user value, not by ease of implementation
 - Ship something real: define an MVP that delivers value, not a wishlist
 - Data over opinions: use metrics to validate priorities when possible
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope
+and no existing Circle role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.

--- a/plugin/skills/scope/SKILL.md
+++ b/plugin/skills/scope/SKILL.md
@@ -110,3 +110,17 @@ Detect the project domain by analyzing files in the current directory:
 - Progressive disclosure: focus only on the analysis phase, don't design solutions
 - Context sharding: create a focused document (aim for clarity, not exhaustiveness)
 - Say no: push back on scope creep during requirements gathering
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope
+and no existing Circle role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.

--- a/plugin/skills/security/SKILL.md
+++ b/plugin/skills/security/SKILL.md
@@ -141,3 +141,17 @@ Based on findings, determine the verdict:
 - Impact over activity: focus on real risks, not security theater
 - Human-in-the-loop: ask for clarification if architecture is unclear, don't assume
 - Speak up: flag risks early and honestly, even when inconvenient
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope
+and no existing Circle role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.

--- a/plugin/skills/ux/SKILL.md
+++ b/plugin/skills/ux/SKILL.md
@@ -92,3 +92,17 @@ Read from `~/.claude/circle/projects/{project}/output/`:
 - Simplicity: the best interface is the one the user doesn't notice
 - Platform conventions: follow platform guidelines unless there's a clear reason not to
 - Accessibility is not optional: design for everyone from the start
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope
+and no existing Circle role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.


### PR DESCRIPTION
## Summary
- Restores `### Communication principles` under `## Holacracy` by moving `## Domain Adaptations` after it — fixes broken section hierarchy in soul.md
- Bumps version to 1.6.2 and adds CHANGELOG entry for governance protocol feature
- Companion to PR #28 (stale `track` removal)

Addresses review comment on #25: https://github.com/alessioroberto82/claude-plugin-circle/pull/25#issuecomment-4169790284

🤖 Generated with [Claude Code](https://claude.ai/claude-code) | Circle Triage