### PR TITLE
chore: post-merge cleanup — v1.7.0, ghost track fix, version sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,9 @@
   "plugins": [
     {
       "name": "circle",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "source": "./plugin",
-      "description": "16 skills (9 holacracy roles + 7 utilities) with structured workflows, quality gates, self-verification guardrails, anti-overcomplication checks, TDD enforcement, security audits, and full customization"
+      "description": "18 skills (9 holacracy roles + 9 utilities) with structured workflows, quality gates, self-verification guardrails, anti-overcomplication checks, TDD enforcement, security audits, and full customization"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ plugin/commands/circle.md              # /circle dashboard
 plugin/resources/soul.md               # Shared principles — every role loads this
 plugin/resources/deps-manifest.yaml    # Dependency registry (source of truth)
 plugin/resources/scripts/              # install-deps.sh, update-deps.sh
-plugin/resources/templates/{docs,software}/ # Output templates
-plugin/skills/*/SKILL.md               # 17 skills (see ls)
+plugin/resources/templates/{docs,software,business,personal}/ # Output templates
+plugin/skills/*/SKILL.md               # 18 skills (see ls)
 docs/                                  # CHANGELOG.md, CUSTOMIZATION.md, GETTING-STARTED.md
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ These run multi-step workflows, guiding you through each phase with decision poi
 | `/circle:validate-prd` | Validates PRD quality against 8 structured checks. Use after creating a PRD, before architecture design |
 | `/circle:tdd` | Enforces strict red-green-refactor TDD cycle. Write a failing test, make it pass, refactor. Used standalone or as sub-workflow of the Implementer |
 | `/circle:shard` | Splits large documents into smaller pieces (called "shards") so roles can work with just the part they need — reduces token usage by ~90% |
+| `/circle:skills-discovery` | Discovers and installs third-party skills with security-gated validation |
 | `/circle:dashboard` | Shows project status: what phase you're in, what's been done, and what roles are available |
 
 > **Token** = the unit of text that AI models process. Fewer tokens means faster responses and lower cost.
@@ -183,7 +184,7 @@ Circle never adds files to your project repository. All outputs are stored in a 
 ├── shards/           # Context shards
 │   ├── requirements/
 │   ├── architecture/
-│   └── stories/
+│   └── tasks/
 ├── workspace/        # Temporary working files
 └── config.yaml       # Per-project overrides
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v1.7.0 — Governance, Skills Discovery & Multi-Domain
+
+### Governance Protocol (from PR #25, #28)
+- **Dynamic role creation** — roles can detect gaps and propose temporary roles via tension format, with human approval required
+- **Promotion rules** — temporary roles used 2+ times get suggested for permanent SKILL.md generation
+- **Role template** — new `resources/templates/software/role-template.md` for generated roles
+- **Tension sensing** — 10 holacracy roles now detect structural gaps and surface them via governance protocol
+
+### Skills Discovery (from PR #26)
+- **New skill: `/circle:skills-discovery`** — security-gated skill install flow with criteria validation
+- **New resource: `skill-security-criteria.md`** — security criteria for evaluating third-party skills
+
+### Multi-Domain Support (from PR #27)
+- **Business & Personal domains** — `init` now detects domain; roles adapt behavior per domain
+- **New templates** — `templates/business/` (5 templates) and `templates/personal/` (5 templates)
+- **Domain adaptations in soul.md** — domain-specific principles for software, business, and personal contexts
+
+### Cleanup
+- **Removed ghost `track` reference** from governance-protocol.md (role was removed in v1.6.1)
+- **Version sync** — plugin.json, marketplace.json, and CHANGELOG aligned at v1.7.0
+- **Skill count** — updated from 16 to 18 (added skills-discovery + governance protocol support)
+
 ## v1.6.2 — Code Review Foundational File Threshold
 
 - **Foundational file threshold** — findings on `soul.md`, root `CLAUDE.md`, and `deps-manifest.yaml` use a lower confidence threshold (75 vs 90) to prevent high-impact issues from being silently filtered

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -144,7 +144,9 @@ This is a settings file that tells Circle roles how to behave differently for a 
 Create `~/.claude/circle/projects/<project-name>/config.yaml`:
 
 ```yaml
-# What kind of project this is (software or general)
+# What kind of project this is (software, business, personal, or general)
+# Detection: software (Package.swift, package.json, etc.), business (business-plan.md,
+# market-analysis.md, strategy.md), personal (goals.md, journal.md, habits/)
 domain: software
 
 # Which optional steps to include in the full workflow

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -122,6 +122,7 @@ Every command starts with `/circle:`. Just type it and press Enter.
 | `/circle:validate-prd` | Validate PRD quality before architecture design |
 | `/circle:tdd` | Enforce test-driven development (red-green-refactor cycle) |
 | `/circle:shard` | Split large documents into smaller pieces (saves time and cost) |
+| `/circle:skills-discovery` | Discover and install third-party skills with security validation |
 | `/circle:init` | Set up Circle for your current project (run once) |
 | `/circle:dashboard` | See project status and what's been done |
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "circle",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Holacracy-based development workflow with distributed roles, quality gates, and Shape Up planning",
   "author": {
     "name": "Alessio Roberto",

--- a/plugin/resources/governance-protocol.md
+++ b/plugin/resources/governance-protocol.md
@@ -36,7 +36,6 @@ Before proposing a new role, verify the gap is real. These roles already exist:
 - **security**: Threat modeling, compliance, audits
 - **shard**: Document sharding for context management
 - **tdd**: TDD red-green-refactor enforcement
-- **track**: Work tracking outside Circle skills
 - **triage**: PR review comment handling
 - **ux**: UI/UX design, wireframes, journeys
 - **validate-prd**: PRD quality validation


### PR DESCRIPTION
## Summary
- Remove ghost `track` role reference from governance-protocol.md (role removed in v1.6.1, reference survived in PR #25)
- Bump version to **1.7.0** across all 3 locations (plugin.json, marketplace.json, CHANGELOG)
- Add v1.7.0 CHANGELOG entry consolidating PRs #25, #26, #27
- Update CLAUDE.md Layout with `business/` and `personal/` template dirs
- Update skill count from 16/17 to 18

## Context
After merging PRs #25 (governance protocol), #26 (skills-discovery), #27 (multi-domain support):
- PR #28 was auto-closed (fix for #25, couldn't push to fork branch)
- PR #30 has merge conflicts (version collision with v1.6.2 from PR #29)
- This PR absorbs the fixes from #28 and resolves the versioning issues from #30

## Test plan
- [ ] Verify `plugin.json`, `marketplace.json`, `CHANGELOG.md` all show v1.7.0
- [ ] Verify `governance-protocol.md` has no `track` role reference
- [ ] Verify CLAUDE.md Layout lists `{docs,software,business,personal}` templates
- [ ] Run `claude --plugin-dir ./plugin` and check `/circle` dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)