### PR TITLE
feat(v2.1.0): pin specific Claude model IDs per skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,16 @@ docs/                                  # CHANGELOG.md, CUSTOMIZATION.md, GETTING
 
 **TDD**: On by default. `impl` uses `/circle:tdd` for red-green-refactor. `qa` verifies via commit history. Disable: `tdd.enabled: false` in config.yaml. Enforcement: `hard` (blocks) or `soft` (warns).
 
-**Model routing**: Fork-context skills specify a default model (opus/sonnet/haiku) in frontmatter `metadata.model`. Orchestrators pass the `model` parameter to Task tool. Override per-project in `config.yaml` under `agents.<name>.model`. Same-context skills inherit the session model.
+**Model routing**: Fork-context skills pin a specific Claude model ID in frontmatter `metadata.model` (e.g., `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`) for cost predictability and stable behavior across Anthropic releases. Orchestrators pass the `model` parameter to Task tool. Override per-project in `config.yaml` under `agents.<name>.model` (accepts both alias and full ID). Same-context skills inherit the session model.
+
+**Cross-provider note**: family aliases (`opus`/`sonnet`/`haiku`) resolve to **different versions on different providers** — latest on Anthropic API; the previous-major on Bedrock/Vertex unless overridden via `ANTHROPIC_DEFAULT_OPUS_MODEL` (or `_SONNET_`, `_HAIKU_`). The plugin's pinned IDs avoid this divergence; Bedrock/Vertex users must confirm the pinned IDs are available on their provider, or override via `agents.<name>.model`.
+
+**Pinned models — current** (as of v2.1.0):
+- Opus: `claude-opus-4-6` → arch, security, impl
+- Sonnet: `claude-sonnet-4-6` → scope, refine, ux, qa, validate-prd, code-review.agent_a, code-review.platform_review
+- Haiku: `claude-haiku-4-5-20251001` → facilitate, code-review.agent_b
+
+Maintainers: monitor [Anthropic deprecation page](https://docs.claude.com/en/docs/about-claude/model-deprecations) and bump pins when a model is retired. The 12 pin sites are: 9 fork-skill frontmatters + 3 entries in `plugin/skills/code-review/SKILL.md` `metadata.model_routing`. Both `plugin/skills/greenfield/SKILL.md` routing tables (Role table + Role Sequence Detail + the JSON `model_routing` example) must stay in sync — see Gotchas.
 
 **Holacracy**: Roles have purposes, not personas. Reference roles, not names. External comms use team voice.
 
@@ -48,3 +57,5 @@ docs/                                  # CHANGELOG.md, CUSTOMIZATION.md, GETTING
 
 - **Marketplace frontmatter**: Only `name`, `description`, `allowed-tools`, `compatibility`, `license`, `metadata` allowed as top-level fields. `context`/`agent` go inside `metadata:`
 - **marketplace.json vs plugin.json**: Different files, different locations (root `.claude-plugin/` vs `plugin/.claude-plugin/`), different purposes
+- **Pinned model drift**: when changing a skill's `metadata.model`, also update the corresponding row in `plugin/skills/greenfield/SKILL.md` (Role table at section "Model & Effort Routing", Role Sequence Detail table, AND the `model_routing` JSON example in the session-state schema). Drift is silent at runtime (skill frontmatter wins) but breaks audit consistency and confuses contributors.
+- **`xhigh` effort is Opus 4.7-only**: do NOT declare `effort: xhigh` on any skill — the plugin pins Opus 4.6 (and Sonnet/Haiku versions that don't support `xhigh`). Stick to `low|medium|high`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## v2.1.0 — Pinned Model IDs
+
+Core skills now pin specific Claude model IDs in their frontmatter (was family aliases). The change gives users cost predictability and stable behaviour across Anthropic releases — Anthropic can ship Opus 4.8 without silently changing how Circle dispatches roles.
+
+### Changed
+
+- **Pinned 12 routing points to specific model IDs** (was family aliases `opus`/`sonnet`/`haiku`):
+  - `arch`, `security`, `impl` → `claude-opus-4-6` (was `opus` → resolved to Opus 4.7)
+  - `scope`, `refine`, `ux`, `qa`, `validate-prd` → `claude-sonnet-4-6`
+  - `facilitate` → `claude-haiku-4-5-20251001`
+  - `code-review.agent_a` → `claude-sonnet-4-6`
+  - `code-review.agent_b` → `claude-haiku-4-5-20251001`
+  - `code-review.platform_review` → `claude-sonnet-4-6`
+- `greenfield/SKILL.md` routing tables (Role table, Role Sequence Detail, JSON `model_routing` example) updated to match.
+- `CLAUDE.md` "Model routing" section rewritten; new "Pinned models — current" reference subsection added; two new Gotchas (pinned model drift, `xhigh` is Opus-4.7-only).
+
+### Added
+
+- `docs/MODEL-ROUTING-VERIFICATION.md` — one-time verification protocol (5 tests using `/cost`) to confirm the per-skill routing actually applies at runtime. Includes privacy guidance for recording results.
+
+### Migration notes
+
+- **Backward compat**: precedence `config.yaml > frontmatter` is unchanged. Users with `agents.<name>.model: opus|sonnet|haiku` in their `config.yaml` will continue to use the alias. To get the new defaults, remove the override or set it to a full model ID.
+- **Bedrock/Vertex users**: confirm the pinned IDs are available on your provider. Anthropic family aliases resolve to different versions on Bedrock/Vertex than on the Anthropic API. If a pin isn't available on your provider, override via `agents.<name>.model` in `config.yaml`.
+- **Maintainers**: monitor [Anthropic deprecation page](https://docs.claude.com/en/docs/about-claude/model-deprecations). When a pinned model is retired, bump the pin in 12 places (9 fork-skill frontmatters + 3 `code-review` `model_routing` entries) and update `greenfield/SKILL.md` tables and `CLAUDE.md` "Pinned models — current".
+
+### Verification
+
+Run the 5-test protocol in `docs/MODEL-ROUTING-VERIFICATION.md` after install. Record results here when completed:
+
+> Verification result (YYYY-MM-DD): Test A/B/C/D/E = pending — to be filled before tagging release.
+
 ## circle-ios v1.1.0 — Local Project Skills + Alternate Apple Docs MCPs
 
 Companion plugin improvement (core `circle` unchanged).

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -192,8 +192,8 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork            # fork = isolated subagent | same = main conversation
   agent: general-purpose   # Explore, Plan, qa, or general-purpose
-  model: sonnet            # opus, sonnet, or haiku
-  effort: medium           # low, medium, high, or max
+  model: claude-sonnet-4-6 # pin a specific model ID — do not use family aliases (opus/sonnet/haiku)
+  effort: medium           # low, medium, high, or max — do not use xhigh (Opus 4.7 only)
 ---
 
 # <Role Name>
@@ -264,38 +264,46 @@ Circle assigns a default Claude model and effort level to each fork-context role
 
 ### Default Assignments
 
+As of v2.1.0, defaults are pinned to specific Claude model IDs (not family aliases) for cost predictability and stable behaviour across Anthropic releases. See CLAUDE.md "Pinned models — current" for the canonical list.
+
 | Role | Default Model | Default Effort | Rationale |
 |------|--------------|----------------|-----------|
-| Scope Clarifier | sonnet | medium | Structured requirements gathering |
-| Refiner | sonnet | medium | Feature prioritization |
-| Experience Designer | sonnet | medium | UX design patterns |
-| Architecture Owner | opus | high | Deep trade-off reasoning |
-| Security Guardian | opus | high | Adversarial threat modeling |
-| Facilitator | haiku | low | Lightweight coordination |
-| Implementer | opus | high | Code generation quality |
-| PRD Validator | sonnet | low | Checklist-based validation |
-| Quality Guardian | sonnet | medium | Criteria-based validation |
+| Scope Clarifier | claude-sonnet-4-6 | medium | Structured requirements gathering |
+| Refiner | claude-sonnet-4-6 | medium | Feature prioritization |
+| Experience Designer | claude-sonnet-4-6 | medium | UX design patterns |
+| Architecture Owner | claude-opus-4-6 | high | Deep trade-off reasoning |
+| Security Guardian | claude-opus-4-6 | high | Adversarial threat modeling |
+| Facilitator | claude-haiku-4-5-20251001 | low | Lightweight coordination |
+| Implementer | claude-opus-4-6 | high | Code generation quality |
+| PRD Validator | claude-sonnet-4-6 | low | Checklist-based validation |
+| Quality Guardian | claude-sonnet-4-6 | medium | Criteria-based validation |
 
-Code review agents (spawned by `code-review` via Task tool) also default to **sonnet**. Configure via `code_review.agent_a_model` and `code_review.agent_b_model` in config.yaml. Note: `code-review` itself is same-context and inherits the session model — only its spawned agents are configurable.
+Code review agents (spawned by `code-review` via Task tool) default to: agent_a → `claude-sonnet-4-6`, agent_b → `claude-haiku-4-5-20251001`, platform_review → `claude-sonnet-4-6`. Configure via `code_review.agent_a.model` / `code_review.agent_b.model` in config.yaml (the legacy flat keys `code_review.agent_a_model` and `code_review.agent_b_model` are still honoured as fallback). Note: `code-review` itself is same-context and inherits the session model — only its spawned agents are configurable.
 
 ### Override via config.yaml
+
+Override accepts either a pinned model ID (recommended — matches the v2.1.0 convention) or a family alias (`opus`/`sonnet`/`haiku`, which resolves to the latest version on the Anthropic API and to the previous-major on Bedrock/Vertex).
 
 ```yaml
 agents:
   arch:
-    model: opus       # deep reasoning tasks
-    effort: high      # high reasoning depth
+    model: claude-opus-4-6        # pinned ID (matches v2.1.0 default)
+    effort: high
   scope:
-    model: sonnet     # structured tasks
-    effort: medium    # moderate reasoning depth
+    model: claude-sonnet-4-6      # pinned ID
+    effort: medium
   facilitate:
-    model: haiku      # lightweight tasks
-    effort: low       # minimal reasoning depth
+    model: claude-haiku-4-5-20251001
+    effort: low
 
-# Code review agent models
+# Code review agent models (use nested keys; legacy flat keys still accepted)
 code_review:
-  agent_a_model: sonnet
-  agent_b_model: sonnet
+  agent_a:
+    model: claude-sonnet-4-6
+    effort: medium
+  agent_b:
+    model: claude-haiku-4-5-20251001
+    effort: medium
 ```
 
 ### Effort Levels

--- a/docs/MODEL-ROUTING-VERIFICATION.md
+++ b/docs/MODEL-ROUTING-VERIFICATION.md
@@ -1,0 +1,122 @@
+# Model Routing Verification Protocol
+
+**Purpose**: confirm that the pinned model IDs declared in each Circle skill's frontmatter are actually applied at runtime when Claude Code dispatches a fork-context skill.
+
+**When to run**: once, after installing or upgrading Circle to v2.1.0 or later, OR after bumping any pinned model ID.
+
+**Why this exists**: the parent session's status line shows the parent model (e.g. `opus 4.7 + xhigh`) and does NOT reflect the model used by sub-agents dispatched via the Task tool. Without this protocol there is no observable signal that per-skill routing works.
+
+---
+
+## Privacy
+
+Do **NOT** paste raw `/cost` output into this CHANGELOG, GitHub issues, or any public artifact. `/cost` may include account-scoped totals, session IDs, or timestamps that you do not want to publish.
+
+When recording results, write only the minimum needed:
+
+> Test X: pass — observed `claude-<family>-<version>`
+
+Strip totals, timestamps, account/session IDs.
+
+---
+
+## Setup
+
+1. Fresh Claude Code session, Circle 2.1.0 (or later) installed via marketplace.
+2. Any working directory — a scratch repo is fine. The verification does not modify the repo.
+3. Confirm the parent session model is **different** from each pinned model below — otherwise you cannot tell whether the per-skill routing is taking effect or you are just seeing the parent's model leak through. Easiest: use a fresh session with the Anthropic API default (Opus 4.7).
+
+**Effort signal**: `/cost` exposes thinking/reasoning tokens per model row. A skill pinned to `effort: low` (e.g. `facilitate`) should burn substantially fewer thinking tokens than the parent session (which typically runs at `xhigh` on Opus 4.7). If a `low`-effort skill shows high thinking-token volume relative to its output, effort routing is NOT applying — file under "fail" alongside any model-routing failures.
+
+---
+
+## Test A — Sonnet pin verification
+
+**Skill under test**: `/circle:scope` — pinned to `claude-sonnet-4-6`.
+
+1. Run `/circle:scope brief test feature for verification` and let it complete.
+2. Run `/cost`.
+3. **Pass criterion**: a row for `claude-sonnet-4-6` appears in `/cost` with non-zero token usage.
+4. **Fail criterion**: only `claude-opus-4-7` (or whatever the parent session model is) appears, with no `claude-sonnet-4-6` row → routing is broken; apply ADR-004 fallback (see `output/arch/architecture.md`).
+
+Record result: `Test A: <pass|fail> — observed <model id>`
+
+---
+
+## Test B — Opus 4.6 pin verification
+
+**Skill under test**: `/circle:arch` — pinned to `claude-opus-4-6`.
+
+1. With requirements in place (e.g. from Test A), run `/circle:arch`.
+2. Run `/cost`.
+3. **Pass criterion**: a row for `claude-opus-4-6` (NOT 4.7) appears with non-zero usage.
+4. **Fail criterion**: only `claude-opus-4-7` appears, or the dispatch errors with "model not found" → routing is broken or the pinned ID is rejected by the Task tool. Fallback per ADR-004.
+
+Record result: `Test B: <pass|fail> — observed <model id>`
+
+---
+
+## Test C — Haiku pin verification
+
+**Skill under test**: `/circle:facilitate` — pinned to `claude-haiku-4-5-20251001`.
+
+1. Run `/circle:facilitate plan a one-day cycle for verification`.
+2. Run `/cost`.
+3. **Pass criterion**: a row for `claude-haiku-4-5-20251001` appears with non-zero usage.
+4. **Fail criterion**: only the parent model appears.
+
+Record result: `Test C: <pass|fail> — observed <model id>`
+
+---
+
+## Test D — code-review multi-agent pin verification
+
+**Skill under test**: `/circle:code-review` — dispatches three sub-agents, each with a different pinned model:
+- `agent_a` → `claude-sonnet-4-6`
+- `agent_b` → `claude-haiku-4-5-20251001`
+- `platform_review` → `claude-sonnet-4-6`
+
+1. On any open PR (or use a tiny test PR), run `/circle:code-review`.
+2. Run `/cost`.
+3. **Pass criterion**: BOTH `claude-sonnet-4-6` AND `claude-haiku-4-5-20251001` rows appear with non-zero usage. (`platform_review` runs only if a platform-review skill matches the diff — its absence is not a failure.)
+4. **Fail criterion**: only one of the two models appears, or the parent model dominates with no Sonnet/Haiku rows → multi-agent routing is broken.
+
+Record result: `Test D: <pass|fail> — observed <models>`
+
+---
+
+## Test E — Smoke load (all remaining fork skills)
+
+**Skills under test**: `/circle:refine`, `/circle:ux`, `/circle:qa`, `/circle:validate-prd`, `/circle:security`, `/circle:impl`. These are not exercised in Tests A-D but share the same pin pattern, so a typo in any of their frontmatters would fail at dispatch.
+
+1. For each of the six skills, invoke it with a minimal prompt (e.g. `/circle:refine status` or `/circle:qa lint`). The goal is **load + dispatch**, not full execution — kill the skill (`Ctrl-C` or `exit`) once it has clearly started.
+2. **Pass criterion**: each skill dispatches without an error like `model not found` or `invalid model identifier`. A skill that prompts for input or starts producing output has dispatched successfully.
+3. **Fail criterion**: any skill returns a "model not found" error → typo in that skill's pinned ID. Read the skill's frontmatter, fix, retry.
+
+Record result: `Test E: <pass|fail> — skills failing: <list or "none">`
+
+---
+
+## Acceptance
+
+All five tests **pass** → record verification in `docs/CHANGELOG.md` under the v2.1.0 entry, replacing the placeholder line:
+
+```
+> Verification result (2026-MM-DD): Test A/B/C/D/E = pass.
+```
+
+If any test **fails** → do NOT tag v2.1.0. Apply the appropriate fallback:
+- Test A or B fail with "model not found" passed to Task tool → apply ADR-004 fallback (modify `greenfield/SKILL.md` to pass family aliases at dispatch time, keep pin in skill frontmatter for direct invocation).
+- Test E fails on a specific skill → typo in that skill's frontmatter; fix and re-run only that test.
+- Other failure modes → open an issue and triage before release.
+
+---
+
+## After Anthropic deprecates a pinned model
+
+When Anthropic announces deprecation of `claude-opus-4-6`, `claude-sonnet-4-6`, or `claude-haiku-4-5-20251001`:
+
+1. Bump the relevant pin in 12 sites (9 fork-skill frontmatters + 3 entries in `plugin/skills/code-review/SKILL.md`).
+2. Update `plugin/skills/greenfield/SKILL.md` (3 tables) and `CLAUDE.md` "Pinned models — current".
+3. Re-run **this entire protocol** before tagging the new minor.
+4. Record the new verification line in CHANGELOG under the new release.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "circle",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Holacracy-based development workflow with distributed roles, quality gates, Shape Up planning, and extensibility contract for platform-review companion plugins",
   "author": {
     "name": "Alessio Roberto",

--- a/plugin/resources/templates/config-example.yaml
+++ b/plugin/resources/templates/config-example.yaml
@@ -40,20 +40,30 @@ tdd:
 # Model & effort routing — assign Claude model and effort level per role
 # Roles with context: fork run as subagents and respect these settings.
 # Roles with context: same inherit the session model (settings are ignored).
-# Model default: inherits from session (usually opus).
-# Effort levels: low, medium, high, max (controls reasoning depth).
+#
+# As of v2.1.0, the plugin pins specific Claude model IDs per role (not family
+# aliases) for cost predictability. The values below mirror the v2.1.0 defaults —
+# you only need to keep entries you actually want to OVERRIDE. Remove any role
+# block to fall back to the plugin default. See CLAUDE.md "Pinned models — current".
+#
+# Override accepts a pinned ID (e.g. claude-opus-4-6, recommended) or a family
+# alias (opus/sonnet/haiku — resolves to latest on Anthropic API, previous-major
+# on Bedrock/Vertex unless you set ANTHROPIC_DEFAULT_OPUS_MODEL etc).
+#
+# Effort levels: low, medium, high, max. Do NOT use xhigh — it is Opus 4.7-only
+# and the plugin pins Opus 4.6.
 # Effort precedence: config.yaml > session-state.json > skill frontmatter default.
 #
 # Role overrides — add model, effort, extra context, or instructions per role
 agents:
   scope:
-    model: sonnet
+    model: claude-sonnet-4-6
     effort: medium
   refine:
-    model: sonnet
+    model: claude-sonnet-4-6
     effort: medium
   arch:
-    model: opus
+    model: claude-opus-4-6
     effort: high
     # Additional files to read for architectural context
     context_files:
@@ -64,16 +74,16 @@ agents:
       This project uses a layered architecture with dependency injection.
       All new modules must follow the existing pattern.
   validate-prd:
-    model: sonnet
+    model: claude-sonnet-4-6
     effort: low
   security:
-    model: opus
+    model: claude-opus-4-6
     effort: high
   facilitate:
-    model: haiku
+    model: claude-haiku-4-5-20251001
     effort: low
   impl:
-    model: opus
+    model: claude-opus-4-6
     effort: high
     context_files:
       - src/
@@ -81,13 +91,13 @@ agents:
       Follow project coding standards and existing conventions.
       All public APIs must have documentation comments.
   qa:
-    model: sonnet
+    model: claude-sonnet-4-6
     effort: medium
     extra_instructions: |
       Minimum test coverage target: 80%.
       Focus on integration tests for data flows.
   ux:
-    model: sonnet
+    model: claude-sonnet-4-6
     effort: medium
     extra_instructions: |
       Follow platform design guidelines.
@@ -101,10 +111,21 @@ parallel:
   enabled: true           # Enable parallel impl (default: true)
   max_agents: 3           # Max concurrent worktree agents (default: 3)
 
-# Code review agent models (code-review spawns 2 parallel agents)
+# Code review agent models (code-review spawns 2 parallel agents).
+# As of v2.1.0, the plugin pins these to specific Claude model IDs.
+# The values below mirror the v2.1.0 defaults; only modify what you want to override.
+# Prefer the nested form (agent_a.model / agent_a.effort); the flat form
+# (agent_a_model) is still honoured as legacy fallback.
 code_review:
-  agent_a_model: sonnet    # Standards & Bugs
-  agent_b_model: sonnet    # Security
+  agent_a:
+    model: claude-sonnet-4-6        # Standards & Bugs
+    effort: medium
+  agent_b:
+    model: claude-haiku-4-5-20251001  # Security
+    effort: medium
+  platform_review:
+    model: claude-sonnet-4-6        # iOS / language-specific platform review (when matched)
+    effort: medium
 
 # Linear project mapping (for MCP integration)
 # linear:

--- a/plugin/resources/templates/software/role-template.md
+++ b/plugin/resources/templates/software/role-template.md
@@ -12,7 +12,11 @@ allowed-tools: []
 metadata:
   context: fork
   agent: general-purpose
-  model: sonnet
+  # Pin a specific model ID — see CLAUDE.md "Pinned models — current".
+  # Do NOT use family aliases like 'sonnet'/'opus'/'haiku' — they resolve to
+  # the latest version and break cost predictability.
+  model: claude-sonnet-4-6
+  effort: medium
 ---
 
 # Role

--- a/plugin/skills/arch/SKILL.md
+++ b/plugin/skills/arch/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
   agent: Plan
-  model: opus
+  model: claude-opus-4-6
   effort: high
 ---
 
@@ -20,11 +20,11 @@ Key reminders: Data over opinions. Document trade-offs honestly. No fear-driven 
 
 ## Model
 
-**Default model**: opus
+**Default model**: `claude-opus-4-6`
 **Override**: Set `agents.arch.model` in project `config.yaml`.
-**Rationale**: Architecture decisions require deep reasoning about trade-offs and system design.
+**Rationale**: Architecture decisions require deep reasoning about trade-offs and system design. Pinned to a specific Opus 4.x version for cost predictability and stable behavior across Anthropic releases.
 
-> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config.
+> When invoked by an orchestrator, use the Task tool with `model: "claude-opus-4-6"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/code-review/SKILL.md
+++ b/plugin/skills/code-review/SKILL.md
@@ -7,14 +7,14 @@ metadata:
   agent: general-purpose
   model_routing:
     agent_a:
-      model: sonnet
+      model: claude-sonnet-4-6
       effort: medium
     agent_b:
-      model: haiku
+      model: claude-haiku-4-5-20251001
       effort: medium
     platform_review:
       enabled: true
-      model: sonnet
+      model: claude-sonnet-4-6
       effort: medium
 ---
 
@@ -112,7 +112,7 @@ Discover installed platform-review skills via the harness's available-skills lis
 3. **Scan available skills**: from the harness-provided skill list, collect skills whose frontmatter declares `metadata.platform_review: true`. Wrap the frontmatter parse for each candidate in a try/catch; on parse error, skip that skill and log `⚠️ Skipped '{skill}' — malformed frontmatter`.
 4. **Match markers against the diff**: for each candidate, read `metadata.platform_markers` (list of glob patterns). Match each glob against the paths from Step 2 using **pure glob matching** — treat patterns as literal match expressions, never pass them to a shell or `eval`. A candidate matches if any of its markers hits any diff path.
 5. **Resolve target**: if one candidate matches, `platform_review_target = <skill-id>`. If multiple match, pick the alphabetically-first by skill id and log `⚠️ Multiple platform-review skills matched: [list]. Using '<chosen>' (alphabetical). Uninstall the one you don't want to silence this.` If none match, `platform_review_target = null`.
-6. **Resolve model/effort** (only when `platform_review_target != null`): dispatched skill's own frontmatter model/effort wins. Fall back to `code_review.platform_review.model` / `.effort`. Final fallback to skill default (`sonnet` / `medium`).
+6. **Resolve model/effort** (only when `platform_review_target != null`): dispatched skill's own frontmatter model/effort wins. Fall back to `code_review.platform_review.model` / `.effort`. Final fallback to skill default (`claude-sonnet-4-6` / `medium`).
 
 **Step 6 — Summary**:
 Summarize: what changed, why, risk areas (2-3 sentences max — internal context, not output). If the PR diff modifies `.claude/` files, flag this as a heightened-attention area.
@@ -146,12 +146,12 @@ Read `~/.claude/circle/projects/{project}/config.yaml` (if it exists). Resolve m
 Agent A (standards, bugs, language best practices):
 1. `code_review.agent_a.model` / `code_review.agent_a.effort` (new nested keys)
 2. `code_review.agent_a_model` (old flat key, backward-compat fallback)
-3. Skill default: `sonnet` / `medium`
+3. Skill default: `claude-sonnet-4-6` / `medium`
 
 Agent B (security):
 1. `code_review.agent_b.model` / `code_review.agent_b.effort` (new nested keys)
 2. `code_review.agent_b_model` (old flat key, backward-compat fallback)
-3. Skill default: `haiku` / `medium`
+3. Skill default: `claude-haiku-4-5-20251001` / `medium`
 
 Pass `model` and `effort` parameters to each Task tool invocation. (Platform-review model/effort resolves separately in step 5c.6 above.)
 

--- a/plugin/skills/facilitate/SKILL.md
+++ b/plugin/skills/facilitate/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
   agent: general-purpose
-  model: haiku
+  model: claude-haiku-4-5-20251001
   effort: low
 ---
 
@@ -20,11 +20,11 @@ Key reminders: Trust the team. Say no to scope creep. Impact over activity.
 
 ## Model
 
-**Default model**: haiku
+**Default model**: `claude-haiku-4-5-20251001`
 **Override**: Set `agents.facilitate.model` in project `config.yaml`.
-**Rationale**: Cycle coordination is structured and lightweight, does not require deep reasoning.
+**Rationale**: Cycle coordination is structured and lightweight, does not require deep reasoning. Pinned to a specific Haiku 4.x version for cost predictability and stable behavior across Anthropic releases.
 
-> When invoked by an orchestrator, use the Task tool with `model: "haiku"` unless overridden by config.
+> When invoked by an orchestrator, use the Task tool with `model: "claude-haiku-4-5-20251001"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/greenfield/SKILL.md
+++ b/plugin/skills/greenfield/SKILL.md
@@ -55,17 +55,19 @@ Each role runs with a recommended Claude model and effort level. The orchestrato
 
 | Role | Default Model | Default Effort | Rationale |
 |------|--------------|----------------|-----------|
-| Scope Clarifier | sonnet | medium | Structured requirements gathering |
-| Refiner | sonnet | medium | Feature prioritization |
-| Experience Designer | sonnet | medium | UX design patterns |
-| Architecture Owner | opus | high | Deep trade-off reasoning |
-| Security Guardian | opus | high | Adversarial threat modeling |
-| Facilitator | haiku | low | Lightweight coordination |
-| Implementer | opus | high | Code generation quality |
-| PRD Validator | sonnet | low | Structured criteria-based validation |
-| Quality Guardian | sonnet | medium | Criteria-based validation |
+| Scope Clarifier | claude-sonnet-4-6 | medium | Structured requirements gathering |
+| Refiner | claude-sonnet-4-6 | medium | Feature prioritization |
+| Experience Designer | claude-sonnet-4-6 | medium | UX design patterns |
+| Architecture Owner | claude-opus-4-6 | high | Deep trade-off reasoning |
+| Security Guardian | claude-opus-4-6 | high | Adversarial threat modeling |
+| Facilitator | claude-haiku-4-5-20251001 | low | Lightweight coordination |
+| Implementer | claude-opus-4-6 | high | Code generation quality |
+| PRD Validator | claude-sonnet-4-6 | low | Structured criteria-based validation |
+| Quality Guardian | claude-sonnet-4-6 | medium | Criteria-based validation |
 
-**Effort levels**: `low`, `medium`, `high`, `max` — controls reasoning depth per role.
+**Models are pinned to specific IDs** (instead of family aliases like `opus`/`sonnet`/`haiku`) for cost predictability and stable behavior across Anthropic releases. Maintainers update these pins when Anthropic deprecates a version.
+
+**Effort levels**: `low`, `medium`, `high`, `max` — controls reasoning depth per role. Note: `xhigh` is intentionally NOT used because it is only supported on Opus 4.7, while the plugin pins Opus 4.6.
 
 **Config override**: `agents.{name}.model` and `agents.{name}.effort` in `~/.claude/circle/projects/{project}/config.yaml`
 
@@ -174,15 +176,15 @@ Optional phases:
         "validate_prd": true/false
       },
       "model_routing": {
-        "scope": "sonnet",
-        "refine": "sonnet",
-        "validate-prd": "sonnet",
-        "ux": "sonnet",
-        "arch": "opus",
-        "security": "opus",
-        "facilitate": "haiku",
-        "impl": "opus",
-        "qa": "sonnet"
+        "scope": "claude-sonnet-4-6",
+        "refine": "claude-sonnet-4-6",
+        "validate-prd": "claude-sonnet-4-6",
+        "ux": "claude-sonnet-4-6",
+        "arch": "claude-opus-4-6",
+        "security": "claude-opus-4-6",
+        "facilitate": "claude-haiku-4-5-20251001",
+        "impl": "claude-opus-4-6",
+        "qa": "claude-sonnet-4-6"
       },
       "effort_routing": {
         "scope": "medium",
@@ -248,15 +250,15 @@ All output paths below are relative to `sessions/{SESSION_ID}/`:
 
 | Step | Role | Model | Effort | Purpose | Input | Output |
 |---|---|---|---|---|---|---|
-| 1 | **Scope Clarifier** | sonnet | medium | Gather requirements | User description | `scope/requirements.md` |
-| 2 | **Refiner** | sonnet | medium | Prioritize & create PRD | Requirements | `refine/PRD-{date}.md` |
-| 3* | **PRD Validator** | sonnet | low | Validate PRD quality | PRD + Requirements | `qa/prd-validation-report.md` |
-| 4* | **Experience Designer** | sonnet | medium | Design UX | PRD | `ux/ux-design.md` |
-| 5 | **Architecture Owner** | opus | high | Design architecture | PRD + UX (if available) | `arch/architecture.md` |
-| 6 | **Security Guardian** | opus | high | Security audit | Architecture | `security/security-audit.md` |
-| 7* | **Facilitator** | haiku | low | Cycle planning | PRD + Architecture | `facilitate/cycle-plan.md` |
-| 8 | **Implementer** | opus | high | Implement | Architecture + PRD | Code in repo |
-| 9 | **Quality Guardian** | sonnet | medium | Test & validate | Requirements + Code | `qa/test-report-{date}.md` |
+| 1 | **Scope Clarifier** | claude-sonnet-4-6 | medium | Gather requirements | User description | `scope/requirements.md` |
+| 2 | **Refiner** | claude-sonnet-4-6 | medium | Prioritize & create PRD | Requirements | `refine/PRD-{date}.md` |
+| 3* | **PRD Validator** | claude-sonnet-4-6 | low | Validate PRD quality | PRD + Requirements | `qa/prd-validation-report.md` |
+| 4* | **Experience Designer** | claude-sonnet-4-6 | medium | Design UX | PRD | `ux/ux-design.md` |
+| 5 | **Architecture Owner** | claude-opus-4-6 | high | Design architecture | PRD + UX (if available) | `arch/architecture.md` |
+| 6 | **Security Guardian** | claude-opus-4-6 | high | Security audit | Architecture | `security/security-audit.md` |
+| 7* | **Facilitator** | claude-haiku-4-5-20251001 | low | Cycle planning | PRD + Architecture | `facilitate/cycle-plan.md` |
+| 8 | **Implementer** | claude-opus-4-6 | high | Implement | Architecture + PRD | Code in repo |
+| 9 | **Quality Guardian** | claude-sonnet-4-6 | medium | Test & validate | Requirements + Code | `qa/test-report-{date}.md` |
 
 *Optional steps
 

--- a/plugin/skills/impl/SKILL.md
+++ b/plugin/skills/impl/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Read, Write, Edit, Grep, Glob, Bash
 metadata:
   context: fork
   agent: general-purpose
-  model: opus
+  model: claude-opus-4-6
   effort: high
 ---
 
@@ -20,11 +20,11 @@ Key reminders: Follow the design. Iteration over perfection. No gold-plating.
 
 ## Model
 
-**Default model**: opus
+**Default model**: `claude-opus-4-6`
 **Override**: Set `agents.impl.model` in project `config.yaml`.
-**Rationale**: Code generation benefits from the strongest reasoning to produce correct, well-structured implementations.
+**Rationale**: Code generation benefits from strong reasoning to produce correct, well-structured implementations. Pinned to a specific Opus 4.x version for cost predictability and stable behavior across Anthropic releases.
 
-> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config.
+> When invoked by an orchestrator, use the Task tool with `model: "claude-opus-4-6"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/qa/SKILL.md
+++ b/plugin/skills/qa/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
   agent: qa
-  model: sonnet
+  model: claude-sonnet-4-6
   effort: medium
 ---
 
@@ -20,11 +20,11 @@ Key reminders: Data over opinions. Measure before claiming success. Speak up abo
 
 ## Model
 
-**Default model**: sonnet
+**Default model**: `claude-sonnet-4-6`
 **Override**: Set `agents.qa.model` in project `config.yaml`.
-**Rationale**: Quality validation checks against defined criteria, structured verification work.
+**Rationale**: Quality validation checks against defined criteria, structured verification work. Pinned to a specific Sonnet 4.x version for cost predictability and stable behavior across Anthropic releases.
 
-> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
+> When invoked by an orchestrator, use the Task tool with `model: "claude-sonnet-4-6"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/refine/SKILL.md
+++ b/plugin/skills/refine/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
   agent: general-purpose
-  model: sonnet
+  model: claude-sonnet-4-6
   effort: medium
 ---
 
@@ -20,11 +20,11 @@ Key reminders: Impact over activity. Say no to scope creep. Data over opinions.
 
 ## Model
 
-**Default model**: sonnet
+**Default model**: `claude-sonnet-4-6`
 **Override**: Set `agents.refine.model` in project `config.yaml`.
-**Rationale**: Feature prioritization is structured decision-making that does not require deep reasoning.
+**Rationale**: Feature prioritization is structured decision-making that does not require deep reasoning. Pinned to a specific Sonnet 4.x version for cost predictability and stable behavior across Anthropic releases.
 
-> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
+> When invoked by an orchestrator, use the Task tool with `model: "claude-sonnet-4-6"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/scope/SKILL.md
+++ b/plugin/skills/scope/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
   agent: Explore
-  model: sonnet
+  model: claude-sonnet-4-6
   effort: medium
 ---
 
@@ -20,11 +20,11 @@ Key reminders: Growth over ego. Ask, don't assume. Flag risks early.
 
 ## Model
 
-**Default model**: sonnet
+**Default model**: `claude-sonnet-4-6`
 **Override**: Set `agents.scope.model` in project `config.yaml`.
-**Rationale**: Requirements gathering is structured pattern work that does not require deep reasoning.
+**Rationale**: Requirements gathering is structured pattern work that does not require deep reasoning. Pinned to a specific Sonnet 4.x version for cost predictability and stable behavior across Anthropic releases.
 
-> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
+> When invoked by an orchestrator, use the Task tool with `model: "claude-sonnet-4-6"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/security/SKILL.md
+++ b/plugin/skills/security/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
   agent: qa
-  model: opus
+  model: claude-opus-4-6
   effort: high
 ---
 
@@ -20,11 +20,11 @@ Key reminders: Impact over activity — focus on real risks, not security theate
 
 ## Model
 
-**Default model**: opus
+**Default model**: `claude-opus-4-6`
 **Override**: Set `agents.security.model` in project `config.yaml`.
-**Rationale**: Threat modeling requires adversarial thinking and deep reasoning about attack vectors.
+**Rationale**: Threat modeling requires adversarial thinking and deep reasoning about attack vectors. Pinned to a specific Opus 4.x version for cost predictability and stable behavior across Anthropic releases.
 
-> When invoked by an orchestrator, use the Task tool with `model: "opus"` unless overridden by config.
+> When invoked by an orchestrator, use the Task tool with `model: "claude-opus-4-6"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/ux/SKILL.md
+++ b/plugin/skills/ux/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Read, Grep, Glob
 metadata:
   context: fork
   agent: Plan
-  model: sonnet
+  model: claude-sonnet-4-6
   effort: medium
 ---
 
@@ -20,11 +20,11 @@ Key reminders: Impact over activity. User needs over developer preferences. Iter
 
 ## Model
 
-**Default model**: sonnet
+**Default model**: `claude-sonnet-4-6`
 **Override**: Set `agents.ux.model` in project `config.yaml`.
-**Rationale**: UX design follows established patterns and conventions, structured output work.
+**Rationale**: UX design follows established patterns and conventions, structured output work. Pinned to a specific Sonnet 4.x version for cost predictability and stable behavior across Anthropic releases.
 
-> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
+> When invoked by an orchestrator, use the Task tool with `model: "claude-sonnet-4-6"` unless overridden by config.
 
 ## Your Role
 

--- a/plugin/skills/validate-prd/SKILL.md
+++ b/plugin/skills/validate-prd/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Read, Grep, Glob, Bash
 metadata:
   context: fork
   agent: qa
-  model: sonnet
+  model: claude-sonnet-4-6
   effort: low
 ---
 
@@ -20,11 +20,11 @@ Key reminders: Data over opinions. Measure before claiming success. No gold-plat
 
 ## Model
 
-**Default model**: sonnet
+**Default model**: `claude-sonnet-4-6`
 **Override**: Set `agents.validate-prd.model` in project `config.yaml`.
-**Rationale**: Structured criteria-based validation; does not require deep reasoning.
+**Rationale**: Structured criteria-based validation; does not require deep reasoning. Pinned to a specific Sonnet 4.x version for cost predictability and stable behavior across Anthropic releases.
 
-> When invoked by an orchestrator, use the Task tool with `model: "sonnet"` unless overridden by config.
+> When invoked by an orchestrator, use the Task tool with `model: "claude-sonnet-4-6"` unless overridden by config.
 
 ## Your Role
 


### PR DESCRIPTION
## Summary

- Replace family aliases (`opus`/`sonnet`/`haiku`) with **pinned model IDs** across 12 routing points (9 fork-skill frontmatters + 3 `code-review.model_routing` entries) for cost predictability and stable behaviour across Anthropic releases.
- Pin map: arch/security/impl → `claude-opus-4-6`; scope/refine/ux/qa/validate-prd, code-review.{agent_a, platform_review} → `claude-sonnet-4-6`; facilitate, code-review.agent_b → `claude-haiku-4-5-20251001`.
- Adds `docs/MODEL-ROUTING-VERIFICATION.md` — a 5-test `/cost`-based protocol to verify per-skill routing post-install (with privacy guidance for recording results).
- Updates greenfield orchestrator (3 routing tables), CLAUDE.md (Model routing rewrite + Pinned models reference + cross-provider note + 2 new Gotchas), CHANGELOG.md (v2.1.0 entry + migration notes), CUSTOMIZATION.md (default table + example config), config-example.yaml template, role-template.md template.
- Bonus: fixes latent bug in `config-example.yaml` where `agent_b_model: sonnet` contradicted the `code-review` skill's haiku default even pre-v2.1.0.

## Why

Pre-v2.1.0 the plugin used family aliases. On the Anthropic API these resolve to the latest in each family — meaning Anthropic could ship Opus 4.8 and silently change how Circle dispatches roles. Pinning gives predictable cost and behaviour; the trade-off is that maintainers must bump pins when Anthropic deprecates a version (deprecation page linked in CLAUDE.md). User-driven request was to use a previous-major Opus for cost; we pivoted from the (retired) Opus 4.5 to Opus 4.6.

## Test plan

The plugin is pure Markdown — no test suite. Verification is a one-time empirical check using Claude Code's `/cost`:

- [ ] Test A — `/circle:scope <prompt>` then `/cost` → expect `claude-sonnet-4-6` row with non-zero usage.
- [ ] Test B — `/circle:arch` then `/cost` → expect `claude-opus-4-6` (NOT 4.7).
- [ ] Test C — `/circle:facilitate <prompt>` then `/cost` → expect `claude-haiku-4-5-20251001`.
- [ ] Test D — `/circle:code-review <PR>` then `/cost` → expect both `claude-sonnet-4-6` AND `claude-haiku-4-5-20251001`.
- [ ] Test E — smoke-load `/circle:refine`, `/circle:ux`, `/circle:qa`, `/circle:validate-prd`, `/circle:security`, `/circle:impl` and confirm none error with "model not found" (catches typos in pin IDs).
- [ ] Effort signal — confirm `low`-effort skills (`facilitate`) burn substantially fewer thinking tokens than the parent session at `xhigh`.

Full protocol: `docs/MODEL-ROUTING-VERIFICATION.md`. Record pass/fail in `docs/CHANGELOG.md` under v2.1.0 (replace the placeholder line) before tagging.

## Post-merge

- Sync `.claude-plugin/marketplace.json` `circle` entry to 2.1.0 (per CLAUDE.md "Three places must match").
- Sync to Luscii claude-marketplace.
- Tag `v2.1.0`.
- Open follow-up for `circle-ios` companion to align in its next minor.

## Migration notes for users

- `config.yaml` precedence (`agents.<name>.model` > frontmatter) is **unchanged**. Users with `model: opus|sonnet|haiku` in their config will keep using the alias. To get the new pinned defaults, remove the override or set it to a full model ID.
- Bedrock/Vertex users: confirm pinned IDs are available on your provider; aliases resolve to **different versions** there. Override via `agents.<name>.model` if needed.

## Pipeline artifacts

Saved to `~/.claude/circle/projects/claude-plugin-circle/output/` (not in this PR):
- `scope/requirements.md` — 6 FR, 4 risks
- `arch/architecture.md` — 7 ADRs + Build Sequence
- `security/security-audit.md` — STRIDE + OWASP, verdict PASS, 4 P3 mitigated
- `impl/implementation-notes-2026-04-28.md` — execution log + fix loop
- `qa/test-report-2026-04-28.md` + `qa/test-report-2026-04-28-followup.md` — verdict PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)