### PR TITLE
fix: triage Luscii PR #28 review comments (gates, security template, layout)

### DIFF
--- a/plugin-ios/README.md
+++ b/plugin-ios/README.md
@@ -9,7 +9,7 @@ claude plugin marketplace add alessioroberto82/claude-plugin-circle
 claude plugin install circle-ios@circle
 ```
 
-Core `/circle:init` does **not** scan this companion's `deps-manifest.yaml`, so it will not prompt for the dependencies below automatically. Install them directly with the commands listed for each dep, or adapt `plugin/resources/scripts/install-deps.sh` from core against `plugin-ios/resources/deps-manifest.yaml`.
+Core `/circle:init` does **not** scan this companion's `deps-manifest.yaml`, so it will not prompt for the dependencies below automatically. Install them directly with the commands listed for each dep, or adapt the core plugin's `resources/scripts/install-deps.sh` against this companion plugin's `resources/deps-manifest.yaml` (resolvable via `${CLAUDE_PLUGIN_ROOT}/resources/deps-manifest.yaml` once the plugin is installed).
 
 ## Dependencies
 

--- a/plugin/resources/deps-manifest.yaml
+++ b/plugin/resources/deps-manifest.yaml
@@ -32,8 +32,9 @@ groups:
         used_by: "all roles"
 
   # iOS / Swift development deps have moved to the companion plugin `circle-ios`
-  # as of v2.0.0. See https://github.com/alessioroberto82/claude-plugin-circle
-  # — plugin-ios/resources/deps-manifest.yaml
+  # as of v2.0.0. See the companion plugin's `resources/deps-manifest.yaml`
+  # (resolvable via `${CLAUDE_PLUGIN_ROOT}/resources/deps-manifest.yaml` from
+  # within the circle-ios plugin context).
 
   extras:
     label: "Additional tools"

--- a/plugin/resources/templates/personal/privacy-audit.md
+++ b/plugin/resources/templates/personal/privacy-audit.md
@@ -3,6 +3,9 @@
 **Date**: [Date]
 **Period Covered**: Current state as of [Date]
 
+> ⚠️ **NEVER record actual passwords, secrets, recovery codes, or 2FA seeds in this document.**
+> This audit captures *metadata about* credentials (strength category, age, breach exposure, reuse) — not the credentials themselves. If you need to track real secrets, use a password manager. Treat this file as if it could be leaked.
+
 ---
 
 ## Executive Summary
@@ -35,10 +38,14 @@
 
 ### Accounts with Weak Passwords
 
-1. **Email ([Provider])**: "[password]" 🔴 CRITICAL
-2. **Bank**: "[password]" 🔴 CRITICAL
-3. **[Account]**: "[password]" 🟡 High priority
-4. [...]
+> Do NOT write actual password values here. Record only metadata.
+
+| # | Account | Strength category | Length | Last rotated | Priority |
+|---|---------|-------------------|--------|--------------|----------|
+| 1 | Email ([Provider]) | Weak (<8 chars) | [N] | [date or "unknown"] | 🔴 CRITICAL |
+| 2 | Bank | Weak | [N] | [date] | 🔴 CRITICAL |
+| 3 | [Account] | Reused | [N] | [date] | 🟡 High |
+| 4 | [...] | [...] | [...] | [...] | [...] |
 
 **Immediate Action Required**:
 - [ ] Change all weak passwords TODAY (especially email, bank)
@@ -47,7 +54,9 @@
 
 ### Reused Passwords
 
-**Password "[X]" reused across**:
+> Identify reuse by *group label* (e.g., "Group A"), not by the password value.
+
+**Reuse group A reused across**:
 - [Account 1]
 - [Account 2]
 - [Account 3]

--- a/plugin/skills/greenfield/SKILL.md
+++ b/plugin/skills/greenfield/SKILL.md
@@ -341,7 +341,7 @@ Progress: [{completed}/{total}]
 Completed:
   ✓ init
   ✓ scope → sessions/{SESSION_ID}/scope/requirements.md
-  ✓ refine → sessions/{SESSION_ID}/refine/PRD.md
+  ✓ refine → sessions/{SESSION_ID}/refine/PRD-{date}.md
   → arch (current)
   ○ impl
   ○ qa
@@ -372,33 +372,47 @@ After the validate-prd step:
 ### Gate 1: Security P0 Block
 
 After the security review step:
-1. Read `$BASE/output/sessions/{SESSION_ID}/security/security-audit.md`
-2. If the document contains "P0" severity issues:
+1. Resolve the security artifact filename based on the project domain (read `domain` from the root of `$BASE/output/session-state.json`):
+   - `software` → `security-audit.md`
+   - `business` → `compliance-report.md`
+   - `personal` → `privacy-audit.md`
+   - any other / unknown → `security-audit.md` (fallback)
+
+   This must match the filename written by the `security` skill (see `security/SKILL.md` Domain-Specific Behavior).
+2. Read `$BASE/output/sessions/{SESSION_ID}/security/{filename}`
+3. If the document contains "P0" severity issues:
    ```
    SECURITY GATE FAILED
    P0 critical issues found in security audit.
    These MUST be resolved before implementation.
 
-   Review: ~/.claude/circle/projects/{project}/output/sessions/{SESSION_ID}/security/security-audit.md
+   Review: ~/.claude/circle/projects/{project}/output/sessions/{SESSION_ID}/security/{filename}
 
    Resolve the issues, then type 'next' to re-run security review.
    ```
-3. Do NOT advance to the Implementer until P0 issues are resolved
+4. Do NOT advance to the Implementer until P0 issues are resolved
 
 ### Gate 2: QA Reject Block
 
 After the Quality Guardian's final verification:
-1. Read `$BASE/output/sessions/{SESSION_ID}/qa/test-report.md`
-2. If verdict is "REJECT":
+1. Resolve the QA report filename prefix based on the project domain (read `domain` from the root of `$BASE/output/session-state.json`):
+   - `software` → `test-report`
+   - `business` → `validation-report`
+   - `personal` → `progress-report`
+   - any other / unknown → `test-report` (fallback)
+
+   This must match the prefix written by the `qa` skill (see `qa/SKILL.md` Domain-Specific Behavior). The skill writes `{prefix}-{date}.md`.
+2. Locate the most recent report under `$BASE/output/sessions/{SESSION_ID}/qa/{prefix}-*.md` (highest mtime, or fall back to lexicographic sort on `{date}` since the skill uses ISO-style date stamps).
+3. If verdict is "REJECT":
    ```
    QA GATE FAILED
    The Quality Guardian has rejected the implementation.
 
-   Review: ~/.claude/circle/projects/{project}/output/sessions/{SESSION_ID}/qa/test-report.md
+   Review: ~/.claude/circle/projects/{project}/output/sessions/{SESSION_ID}/qa/{report-filename}
 
    Fix the issues with /circle:impl, then re-run QA.
    ```
-3. Loop back to Implementer step
+4. Loop back to Implementer step
 
 ### Gate 3: Completeness Check
 


### PR DESCRIPTION
## Summary

Source-side fixes for review comments on [Luscii/claude-marketplace#28](https://github.com/Luscii/claude-marketplace/pull/28). Once merged here, the v2.x bundle should be re-synced to Luscii so the marketplace PR can be unblocked.

- **Quality gates** (#1, #3, #7) — Greenfield Gates 1 and 2 hardcoded artifact filenames that don't match what the producing skills actually write. Gate 1 missed P0s in `business`/`personal` domains; Gate 2 never found the (date-stamped) QA report. Both now resolve filename via the session's `domain` field. Detailed status example also updated to `PRD-{date}.md`.
- **Privacy audit template** (#4) — Removed `"[password]"` placeholders that invited users to paste real credentials into reports. Now records metadata only (strength category, length, last-rotated, breach exposure) and warns at the top of the file.
- **Layout-agnostic refs** (#2, #5) — `plugin-ios/...` paths broke under Luscii's `plugins/circle-ios/` layout. Replaced with neutral phrasing + `${CLAUDE_PLUGIN_ROOT}` reference.

## Out of scope (Luscii-only)

Comment #6 (description mismatch between Luscii's `marketplace.json` line 24 and `circle-ios/plugin.json`) cannot be fixed from this repo. Source-of-truth string is in `plugin-ios/.claude-plugin/plugin.json`; the Luscii PR must be edited directly to match it.

## Test plan

- [ ] Read [plugin/skills/greenfield/SKILL.md](plugin/skills/greenfield/SKILL.md) Gate 1 / Gate 2 / status-example sections for clarity
- [ ] Confirm Gate 1 filename mapping matches `security/SKILL.md` Domain-Specific Behavior
- [ ] Confirm Gate 2 prefix mapping matches `qa/SKILL.md` Domain-Specific Behavior (`{prefix}-{date}.md`)
- [ ] Read [plugin/resources/templates/personal/privacy-audit.md](plugin/resources/templates/personal/privacy-audit.md) — verify no remaining `"[password]"` placeholders
- [ ] Verify [plugin-ios/README.md](plugin-ios/README.md) and [plugin/resources/deps-manifest.yaml](plugin/resources/deps-manifest.yaml) no longer reference the source-repo-specific `plugin-ios/...` path

## Notes

No version bump or CHANGELOG entry per the triage request — batch into the next sync to Luscii.