### PR TITLE
chore: sync marketplace.json to plugin v2.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "circle",
-      "version": "2.0.0",
+      "version": "2.2.1",
       "source": "./plugin",
       "description": "18 skills (9 holacracy roles + 9 utilities) — domain-agnostic core with extensibility contract for platform-review companion plugins; structured workflows, quality gates, self-verification guardrails, anti-overcomplication checks, TDD enforcement, and security audits"
     },


### PR DESCRIPTION
## Summary

Post-merge marketplace sync per `CLAUDE.md` release procedure. Bumps the `circle` entry in `.claude-plugin/marketplace.json` from 2.0.0 → 2.2.1 to match the current `plugin/.claude-plugin/plugin.json`.

The marketplace.json had not been bumped since v2.0.0 (last companion-plugin sync). This single bump catches it up through three intermediate releases:

- v2.1.0 — pinned model IDs ([#38](https://github.com/alessioroberto82/claude-plugin-circle/pull/38))
- v2.2.0 — Task tool alias routing ([#40](https://github.com/alessioroberto82/claude-plugin-circle/pull/40))
- v2.2.1 — code-review design-intent gate ([#41](https://github.com/alessioroberto82/claude-plugin-circle/pull/41))

## Test plan

- [ ] `circle` entry version reads 2.2.1
- [ ] `circle-ios` entry unchanged at 1.1.0
- [ ] Post-merge: sync Luscii `claude-marketplace` mirror to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)