### PR TITLE
chore: sync marketplace.json to plugin v2.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "circle",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "source": "./plugin",
       "description": "19 skills (9 holacracy roles + 10 utilities) — domain-agnostic core with extensibility contract for platform-review companion plugins; structured workflows, quality gates, multi-perspective decision council, self-verification guardrails, anti-overcomplication checks, TDD enforcement, and security audits"
     },


### PR DESCRIPTION
Post-merge sync after #44 (no-mistakes integration v2.4.0).

Aligns the `circle` entry in `.claude-plugin/marketplace.json` with `plugin/.claude-plugin/plugin.json` (both now `2.4.0`), per the version-bump policy in CLAUDE.md (three places must match: plugin.json, marketplace.json, Luscii).

🤖 Generated with [Claude Code](https://claude.com/claude-code)