### PR TITLE
feat: digest handoff on scope→arch (Phase 2 PR-A, flag default OFF)

### DIFF
--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -173,6 +173,15 @@ agents:
 tdd:
   enabled: true           # Set to false to disable TDD workflow
   enforcement: hard       # hard = QA blocks on violation; soft = QA warns only
+
+# Handoff digest (Phase 2 — token reduction)
+# When true, each role writes a compact handoff-digest.md at handoff and
+# downstream roles read it as their primary input (escalating to the full
+# document on demand). guardrails builds its Traceability table from the
+# digest too. Default false = roles read full upstream docs as before.
+# Currently wired on the scope→arch hop only.
+handoff:
+  digest: false           # Set to true to enable digest handoff
 ```
 
 See `plugin/resources/templates/config-example.yaml` for a full example with all available options.

--- a/docs/superpowers/plans/2026-07-08-digest-handoff-pra.md
+++ b/docs/superpowers/plans/2026-07-08-digest-handoff-pra.md
@@ -1,0 +1,316 @@
+# Digest Handoff (PR-A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire a compact handoff-digest mechanism on the single scope→arch hop, fully behind config flag `handoff.digest` (default OFF), so downstream reads a small digest instead of the full upstream doc — with identical behavior when the flag is off.
+
+**Architecture:** `scope` writes `scope/handoff-digest.md` at handoff (flag-guarded). `arch` reads that digest first and escalates to the full doc on demand (flag-guarded). `guardrails.md` self-verification builds its Traceability table from the digest, falling back to the full doc if the digest is absent (flag-guarded). A new resource template defines the digest schema. All edits are prompt/Markdown — no code.
+
+**Tech Stack:** Pure Markdown plugin for Claude Code. No build, no tests, no CI. "Verification" = grep-based structural checks + manual flag-OFF/ON dry-run against `session-state`/`config.yaml` conventions.
+
+## Global Constraints
+
+- **Domain-agnostic core**: no domain-specific tool names in SKILL bodies outside allowed sections (CLAUDE.md).
+- **Flag key**: `handoff.digest`, boolean, nested convention (like `tdd.enabled`, `guardrails.self_check`, `parallel.enabled`). Default **OFF** (treat absent/false identically).
+- **Flag OFF ⇒ zero behavioral change**: when off, no digest is read or written; the role reads/writes exactly as on current `main`.
+- **Additive**: the full upstream document is ALWAYS still written; the digest never replaces it. Greenfield gates (full-doc filenames) are untouched.
+- **Graceful degradation**: flag ON but digest missing ⇒ consumer falls back to the full doc, no hard failure.
+- **Scope**: scope→arch hop ONLY. Do not touch refine/ux/impl/qa/security/other hops.
+- **No version bump / no default flip** in PR-A (that is PR-B).
+- **Branch**: `feat/digest-handoff` (already checked out; spec commit `4c61994` present).
+- **Digest path**: `~/.claude/circle/projects/{project}/output/scope/handoff-digest.md`.
+- **Digest size target**: ~300–600 tokens.
+
+---
+
+### Task 1: Digest schema template resource
+
+**Files:**
+- Create: `plugin/resources/handoff-digest-template.md`
+
+**Interfaces:**
+- Produces: the digest schema consumed by Task 2 (producer) and referenced by Tasks 3–4 (consumers). Sections (exact headings): `## Verifiable items`, `## Key decisions`, `## Interface for next role`, `## Escalation hints`. Header line format: `# Handoff Digest — {role} → {next role}` and a `**Source doc**: {path}   **Domain**: {domain}` line.
+
+- [ ] **Step 1: Create the template file**
+
+Create `plugin/resources/handoff-digest-template.md` with exactly:
+
+```markdown
+# Handoff Digest Template
+
+Output this compact digest at handoff **only when** `handoff.digest: true` in the
+project `config.yaml`. Write it alongside (never instead of) the full document.
+Target ~300–600 tokens. Fill every section from THIS session's work; do not invent.
+
+```
+# Handoff Digest — {role} → {next role}
+**Source doc**: {relative path to the full document}   **Domain**: {software|business|personal|general}
+
+## Verifiable items
+| ID | Item | One-line essence |
+|----|------|------------------|
+| FR-1 | {short label} | {one line} |
+
+## Key decisions
+- {decision} — {one-line why}
+
+## Interface for next role
+- {what the next role needs to begin without opening the full doc}
+
+## Escalation hints
+- For detail on {topic}, see §{section} of the source doc
+```
+
+## Guidance
+- **Verifiable items**: one row per checkable item the downstream role and
+  guardrails must trace (FR-*, NFR, work items, components, acceptance criteria —
+  whatever your role produces). This list IS the guardrails checklist.
+- **Key decisions**: only choices that constrain the downstream role (e.g. explicit
+  out-of-scope items, a chosen constraint). Skip narration.
+- **Interface for next role**: the minimal contract to start work.
+- **Escalation hints**: map topics to source-doc sections so escalation is cheap.
+```
+
+- [ ] **Step 2: Verify structure**
+
+Run: `grep -E "^(## Verifiable items|## Key decisions|## Interface for next role|## Escalation hints)$" plugin/resources/handoff-digest-template.md | wc -l`
+Expected: `4`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugin/resources/handoff-digest-template.md
+git commit -m "feat(resources): add handoff-digest template (Phase 2 PR-A)"
+```
+
+---
+
+### Task 2: scope produces the digest at handoff (flag-guarded)
+
+**Files:**
+- Modify: `plugin/skills/scope/SKILL.md` (Process section — insert a new step after "Save output", before "MCP Integration"; renumber following steps)
+
+**Interfaces:**
+- Consumes: template from Task 1 at `${CLAUDE_PLUGIN_ROOT}/resources/handoff-digest-template.md`.
+- Produces: `scope/handoff-digest.md` (read by Tasks 3 and 4). Written only when `handoff.digest: true`.
+
+- [ ] **Step 1: Insert the digest-production step**
+
+In `plugin/skills/scope/SKILL.md`, replace the block starting at "5. **Save output**" through "6. **MCP Integration**" — old text:
+
+```
+5. **Save output** to: `~/.claude/circle/projects/$PROJECT_NAME/output/scope/{filename}`
+
+6. **MCP Integration** (if available):
+```
+
+with:
+
+```
+5. **Save output** to: `~/.claude/circle/projects/$PROJECT_NAME/output/scope/{filename}`
+
+6. **Write handoff digest** (only if enabled): Read `~/.claude/circle/projects/$PROJECT_NAME/config.yaml`. If `handoff.digest` is not `true`, skip this step entirely (default). Otherwise, read `${CLAUDE_PLUGIN_ROOT}/resources/handoff-digest-template.md` and write a filled digest to `~/.claude/circle/projects/$PROJECT_NAME/output/scope/handoff-digest.md`:
+   - **Verifiable items**: one row per FR-* and NFR in the requirements doc, each with a one-line essence.
+   - **Key decisions**: scope choices that constrain downstream (e.g. explicit Out-of-Scope items).
+   - **Interface for next role**: what the Architecture Owner needs to begin.
+   - **Escalation hints**: map topics to sections of the source doc (`{filename}`).
+   Keep it ~300–600 tokens. The full document from step 5 is always still written — the digest is additive.
+
+7. **MCP Integration** (if available):
+```
+
+- [ ] **Step 2: Renumber the remaining steps**
+
+In the same file, apply these exact replacements (Work Summary and Handoff shift by one):
+
+Replace `7. **Work Summary**:` with `8. **Work Summary**:`
+Replace `8. **Handoff**:` with `9. **Handoff**:`
+
+- [ ] **Step 3: Verify guard wording and numbering**
+
+Run: `grep -nE "handoff\.digest|Write handoff digest|^8\. \*\*Work Summary|^9\. \*\*Handoff" plugin/skills/scope/SKILL.md`
+Expected: 3 matches — the guard mention inside step 6, the step-6 title, `8. **Work Summary**`, `9. **Handoff**` (grep reports each line; confirm no duplicate step numbers remain).
+
+Run: `grep -c "handoff-digest.md" plugin/skills/scope/SKILL.md`
+Expected: `1`
+
+- [ ] **Step 4: Verify flag-OFF parity (dry read)**
+
+Read the modified step 6. Confirm the first sentence makes the digest path conditional on `handoff.digest` being `true` and says to skip otherwise. This is the flag-OFF guarantee.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/skills/scope/SKILL.md
+git commit -m "feat(scope): produce handoff digest at handoff when handoff.digest enabled"
+```
+
+---
+
+### Task 3: arch reads digest-first with escalation (flag-guarded)
+
+**Files:**
+- Modify: `plugin/skills/arch/SKILL.md` (Input Prerequisites section)
+
+**Interfaces:**
+- Consumes: `scope/handoff-digest.md` from Task 2.
+- Produces: the escalation rule text (referenced conceptually by verification; no downstream code dependency).
+
+- [ ] **Step 1: Add the digest-first block to Input Prerequisites**
+
+In `plugin/skills/arch/SKILL.md`, find the Input Prerequisites list. Replace this exact block:
+
+```
+Read requirements from `~/.claude/circle/projects/{project}/output/`:
+- Check for: `scope/requirements.md`
+- Also check: `refine/PRD.md` (if Refiner has refined requirements)
+- If none found: "Requirements missing. Run `/circle:scope` first to gather requirements."
+```
+
+with:
+
+```
+Read requirements from `~/.claude/circle/projects/{project}/output/`:
+- **Digest-first (only if enabled)**: read `~/.claude/circle/projects/{project}/config.yaml`. If `handoff.digest` is `true` AND `scope/handoff-digest.md` exists, read the digest as your PRIMARY input instead of the full doc. **Escalation rule**: if a decision depends on a detail not present in the digest, open the source doc named in the digest (use its Escalation hints to jump to the right section) before proceeding — do not guess. If the flag is off or the digest is absent, fall back to the full doc below (default behavior).
+- Check for: `scope/requirements.md`
+- Also check: `refine/PRD.md` (if Refiner has refined requirements)
+- If none found: "Requirements missing. Run `/circle:scope` first to gather requirements."
+```
+
+- [ ] **Step 2: Verify guard + escalation wording**
+
+Run: `grep -nE "Digest-first|handoff\.digest|Escalation rule|do not guess" plugin/skills/arch/SKILL.md`
+Expected: at least the 4 phrases present on the inserted lines.
+
+Run: `grep -c "handoff-digest.md" plugin/skills/arch/SKILL.md`
+Expected: `1`
+
+- [ ] **Step 3: Verify flag-OFF + fallback parity (dry read)**
+
+Read the inserted bullet. Confirm it (a) gates on `handoff.digest` being `true`, (b) also requires the digest file to exist, (c) explicitly falls back to the full doc otherwise. This guarantees identical behavior when off and graceful degradation when on-but-missing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugin/skills/arch/SKILL.md
+git commit -m "feat(arch): read scope handoff digest first with on-demand escalation"
+```
+
+---
+
+### Task 4: guardrails builds traceability from the digest (flag-guarded, with fallback)
+
+**Files:**
+- Modify: `plugin/resources/guardrails.md` (Upstream Artifact Mapping note + Protocol step 1)
+
+**Interfaces:**
+- Consumes: `scope/handoff-digest.md` `## Verifiable items` section (Task 1 schema, produced by Task 2).
+- Note: only the arch row of the mapping is in scope for PR-A; other rows keep current behavior.
+
+- [ ] **Step 1: Add a digest note under the Upstream Artifact Mapping table**
+
+In `plugin/resources/guardrails.md`, find this exact line (immediately after the mapping table):
+
+```
+Read the upstream artifact from `~/.claude/circle/projects/{project}/output/`. If the first path doesn't exist, try the alternative (e.g., PRD.md if requirements.md is missing).
+```
+
+Replace it with:
+
+```
+Read the upstream artifact from `~/.claude/circle/projects/{project}/output/`. If the first path doesn't exist, try the alternative (e.g., PRD.md if requirements.md is missing).
+
+**Digest source (only if enabled)**: if `handoff.digest` is `true` in `config.yaml` AND the upstream role wrote a `handoff-digest.md`, take your checklist from that digest's `## Verifiable items` section instead of re-reading the full upstream doc. If the flag is off or no digest exists, use the full artifact as described above (default behavior). For PR-A this applies to the `arch` role reading `scope/handoff-digest.md`; other roles keep reading the full artifact.
+```
+
+- [ ] **Step 2: Point Protocol step 1 at the digest when present**
+
+In the same file, replace this exact line:
+
+```
+1. Extract the list of checkable items from the upstream artifact (FR-*, work items, components, acceptance criteria — depending on your role's "Check For" column above).
+```
+
+with:
+
+```
+1. Extract the list of checkable items (FR-*, work items, components, acceptance criteria — per your role's "Check For" column). Source them from the upstream `handoff-digest.md` `## Verifiable items` section when the digest path above applies; otherwise from the full upstream artifact.
+```
+
+- [ ] **Step 3: Verify wording**
+
+Run: `grep -nE "Digest source|handoff\.digest|Verifiable items" plugin/resources/guardrails.md`
+Expected: the note + step-1 reference present (≥3 matches).
+
+- [ ] **Step 4: Verify flag-OFF parity (dry read)**
+
+Read both edited spots. Confirm each states the digest path is taken only when `handoff.digest` is `true` AND a digest exists, and that the full-doc path remains the default/fallback. Confirm the note scopes PR-A to arch←scope.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/resources/guardrails.md
+git commit -m "feat(guardrails): build traceability from handoff digest with full-doc fallback"
+```
+
+---
+
+### Task 5: Document the `handoff.digest` flag
+
+**Files:**
+- Modify: `docs/CUSTOMIZATION.md` (config / per-project settings section)
+
+**Interfaces:**
+- Consumes: nothing. Produces: user-facing documentation of the flag.
+
+- [ ] **Step 1: Locate the config-options section**
+
+Run: `grep -nE "guardrails|self_check|tdd\.enabled|parallel|config\.yaml" docs/CUSTOMIZATION.md | head`
+Expected: shows where per-project `config.yaml` options are documented. Choose the block that lists boolean feature flags (near `guardrails.self_check` / `tdd.enabled`).
+
+- [ ] **Step 2: Add the flag documentation**
+
+Immediately after the existing `guardrails.self_check` (or nearest feature-flag) entry, insert:
+
+```markdown
+### `handoff.digest` (default: `false`)
+
+When `true`, each role writes a compact `handoff-digest.md` at handoff and downstream roles read that digest as their primary input (escalating to the full document on demand). The `guardrails` self-verification builds its Traceability table from the digest too. When `false` (default), roles read the full upstream documents exactly as before — no digest is written or read. Currently wired on the scope→arch hop only.
+
+```yaml
+handoff:
+  digest: true
+```
+```
+
+(If no feature-flag block exists, add a new `## Config: handoff.digest` section following the file's existing heading style.)
+
+- [ ] **Step 3: Verify**
+
+Run: `grep -nE "handoff\.digest|handoff:|digest: true" docs/CUSTOMIZATION.md`
+Expected: the heading + the YAML example present.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/CUSTOMIZATION.md
+git commit -m "docs(customization): document handoff.digest config flag"
+```
+
+---
+
+## Post-implementation validation (spec §5 — not a code task)
+
+Do this after all tasks land, before writing PR-B:
+
+1. **Flag-OFF parity**: with no `handoff.digest` in `config.yaml`, run a scope→arch dry run (or re-read the three edited files) and confirm no digest read/write path is taken — behavior matches current `main`.
+2. **Flag-ON happy path**: set `handoff.digest: true`, run `/circle:scope` then `/circle:arch` on a scratch feature. Confirm: `scope/handoff-digest.md` is created and well-formed (4 schema sections); arch's output still addresses every FR; guardrails' Traceability table is populated from the digest.
+3. **Flag-ON missing digest**: with flag on but `scope/handoff-digest.md` deleted, confirm arch and guardrails fall back to the full doc without error.
+4. **Token measurement**: use the transcript analyzer (`~/.claude/projects/.../*.jsonl`, `attributionSkill`+`usage`) to compare the `arch` fork's fresh (cache_creation) tokens OFF vs ON on the same input. Record the delta — this decides whether PR-B (extend + flip default) proceeds.
+5. **qa lint**: run `/circle:qa lint`; confirm all 8 checks still pass.
+
+## Self-Review notes
+
+- **Spec coverage**: §1 template → Task 1; §1 producer + §4 flag → Task 2; §2 digest-first + escalation → Task 3; §3 guardrails unification → Task 4; §4 config doc → Task 5; §5 pilot/measurement → Post-implementation validation. All spec sections mapped.
+- **Type/name consistency**: digest filename `handoff-digest.md`, flag `handoff.digest`, and section headings (`## Verifiable items`, etc.) are used identically across Tasks 1–5.
+- **No version bump** in any task (PR-A constraint honored).

--- a/docs/superpowers/specs/2026-07-08-circle-digest-handoff-design.md
+++ b/docs/superpowers/specs/2026-07-08-circle-digest-handoff-design.md
@@ -1,0 +1,130 @@
+# Design Spec: Digest Handoff Between Circle Roles (Phase 2)
+
+**Date**: 2026-07-08
+**Status**: Approved design → ready for implementation plan
+**Plugin version target**: 2.5.0 (minor — new opt-in mechanism)
+**Prereq**: Phase 1 (boilerplate compression, v2.4.1, PR #46) — merged.
+
+## Context
+
+Circle's fork-context roles (`arch, security, impl, scope, refine, ux, qa, facilitate, validate-prd`) cost 100K–460K *fresh* (cache_creation) tokens per invocation. Profiling of real session transcripts (`~/.claude/projects/-Users-alessioroberto-Projects-claude-plugin-circle/*.jsonl`, fields `attributionSkill` + `usage`) established that the dominant cost is **not** the SKILL.md prose (all static plugin content is <3% of a fork). It is:
+
+1. **Full upstream-doc reloads** — each downstream role reads the entire upstream artifact (`requirements.md`, `PRD.md`, `architecture.md`) as input.
+2. **A second full read inside `guardrails.md`** — self-verification re-reads the *same* full upstream doc to extract checkable items and build a Traceability table.
+3. (Amplifier) **Prompt-cache expiry** across human-in-the-loop pauses re-bills whatever is loaded.
+
+Today there is **no digest path**: `work-summary-template.md` is output-only (consumed by claude-mem, never read by the next role). This spec introduces a compact **handoff digest** so downstream roles and guardrails read a small structured artifact instead of the full document — attacking costs (1) and (2) directly.
+
+## Goals
+
+- Downstream roles start from a compact digest, loading the full upstream doc **only on demand**.
+- Eliminate the guardrails second full-doc read by feeding it the same digest.
+- **No quality regression** and **no behavioral change when disabled**.
+- Ship behind a config flag (default OFF), validate on one hop, then flip default ON.
+
+## Non-goals
+
+- Removing or shrinking the full upstream documents (they remain canonical, human-facing, and the escalation target).
+- Changing greenfield gates or the per-domain output filenames they resolve.
+- Replacing the claude-mem Work Summary (separate artifact, separate consumer).
+
+## Decisions (from brainstorming)
+
+1. **Producer**: the role itself, at handoff. It already holds full context in memory → marginal cost ≈ zero, highest fidelity, no extra full-doc read. Written in the same handoff phase as the Traceability section and Work Summary.
+2. **Authority model**: digest-first + on-demand escalation. The digest is the primary input; the downstream role opens the full doc only when a decision needs a detail the digest lacks.
+3. **Schema**: a fixed structured "handoff contract" whose *Verifiable items* list is exactly what guardrails needs — one artifact, two uses.
+4. **Rollout**: config flag `handoff.digest`, default OFF at first merge; validate one hop (scope→arch), then a follow-up PR flips default ON.
+
+## Design
+
+### §1 — The digest artifact and schema
+
+Each fork role, at handoff, writes a compact file **alongside** the full document (which is always still written — the digest is additive):
+
+- Path: `~/.claude/circle/projects/{project}/output/{role}/handoff-digest.md`
+  (e.g. `scope/handoff-digest.md` next to `scope/requirements.md`)
+- Target size: ~300–600 tokens (vs multiple thousands for the full doc).
+
+Fixed schema:
+
+```markdown
+# Handoff Digest — {role} → {next role}
+**Source doc**: {relative path to the full document}   **Domain**: {software|business|personal|general}
+
+## Verifiable items
+| ID | Item | One-line essence |
+|----|------|------------------|
+| FR-1 | ... | ... |
+
+## Key decisions
+- {decision} — {one-line why}
+
+## Interface for next role
+- {what the next role needs to start without opening the full doc}
+
+## Escalation hints
+- For detail on {X}, see §{section} of the source doc
+```
+
+- **Verifiable items** enumerate the same items guardrails extracts today (FR-*, work items, components, acceptance criteria — depending on the role). This is the pivot that lets one artifact serve both consumers.
+- **Key decisions** lists only choices that constrain the downstream role.
+- **Interface for next role** is the minimal contract to begin work.
+- **Escalation hints** map topics → source-doc sections so escalation is cheap and targeted.
+
+### §2 — Data flow and escalation rule
+
+- A downstream role's *Input Prerequisites* reads the upstream **digest first**, not the full doc.
+- Explicit escalation rule added to each consuming role's body:
+  > "If a decision depends on a detail not present in the digest, open the source doc named in the digest (use its Escalation hints to jump to the relevant section) before proceeding. Do not guess."
+- The full doc remains for: on-demand escalation, greenfield gates (which read full-doc filenames — unchanged), and human readers.
+
+### §3 — Guardrails unification
+
+`guardrails.md` Self-Verification Protocol changes:
+
+- Step 1 becomes: "Read the **Verifiable items** section of the upstream `handoff-digest.md`; use it as the checklist. Open the full source doc only if the digest is missing or incomplete (graceful degradation)."
+- The Upstream Artifact Mapping table points at `{upstream-role}/handoff-digest.md` (with the full doc as fallback).
+- The Traceability table is built from the digest's item list. This removes the second full-doc read.
+
+### §4 — Config and gating
+
+- New `config.yaml` key: `handoff.digest` (boolean, **default `false`**).
+- When `false`: roles read full docs and guardrails re-reads full docs — **identical to current behavior, zero risk**.
+- When `true`: producers emit the digest at handoff; consumers read digest-first; guardrails builds traceability from the digest.
+- Consistent with existing flags (`tdd.enabled`, `guardrails.self_check`).
+- **Graceful degradation**: if `handoff.digest: true` but an upstream digest is absent (e.g. produced before the flag was on), the consumer falls back to the full doc. No hard failure.
+
+### §5 — Pilot scope and measurement
+
+- **This PR (PR-A)**: full mechanism behind the flag (OFF), wired on **one hop only — scope→arch**:
+  - `scope` produces `scope/handoff-digest.md` at handoff.
+  - `arch` reads the digest-first (guarded by the flag) and applies the escalation rule.
+  - `guardrails` builds arch's traceability from scope's digest (guarded by the flag).
+  - All other hops unchanged.
+- **Validation** (before rollout): run scope→arch on the same input with the flag OFF vs ON. Measure:
+  - (a) fresh (cache_creation) tokens of the `arch` fork — via the transcript analyzer written this session.
+  - (b) output quality — does arch's architecture still address every FR? Manual comparison of the two arch outputs + traceability completeness.
+- **Follow-up PR (PR-B)**, only if validation is green: extend digest production/consumption to all hops and flip `handoff.digest` default to `true`. Version bump accordingly.
+
+## Risks and mitigations
+
+- **Dual source of truth (digest vs full doc)**: mitigated — the digest is generated by the role that owns the doc, in the same handoff, and cites the doc as canonical. The digest never contradicts; it summarizes + points.
+- **Quality regression from thinner context**: mitigated — digest-first + explicit escalation rule + full doc always present; validated one hop before broad rollout; default OFF until proven.
+- **Savings depend on upstream doc size**: real numbers unknown until the pilot measures them — hence measure-before-extend.
+
+## Files affected (implementation targets)
+
+- `plugin/resources/handoff-digest-template.md` — **new** template (the schema in §1).
+- `plugin/skills/scope/SKILL.md` — add digest production at handoff (flag-guarded).
+- `plugin/skills/arch/SKILL.md` — Input Prerequisites digest-first + escalation rule (flag-guarded).
+- `plugin/resources/guardrails.md` — read digest for the checklist, full doc as fallback (flag-guarded); update Upstream Artifact Mapping.
+- `docs/CUSTOMIZATION.md` — document the `handoff.digest` config flag.
+- `docs/CHANGELOG.md` + `plugin/.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` — version bump on the rollout PR.
+
+## Verification
+
+1. **Flag OFF = no change**: with `handoff.digest` absent/false, diff scope/arch/guardrails behavior against current `main` — must be identical (no digest read/write path taken).
+2. **Flag ON, happy path**: scope writes a well-formed digest; arch consumes it; guardrails builds traceability from it; arch output still covers all FRs.
+3. **Flag ON, missing digest**: consumer falls back to full doc without error (graceful degradation).
+4. **Token measurement**: analyzer confirms a reduction in arch's fresh tokens, OFF vs ON, on the same input.
+5. **qa lint**: `/circle:qa lint` still passes (no gate/registry/domain-detection regressions).

--- a/plugin/resources/guardrails.md
+++ b/plugin/resources/guardrails.md
@@ -13,7 +13,7 @@ Before handoff, verify your output covers upstream requirements. This closes the
 
 | Your Role | Read This | Check For |
 |---|---|---|
-| arch | `scope/requirements.md` or `refine/PRD.md` | Each FR-*/work item addressed in architecture |
+| arch | `scope/requirements.md` or `refine/PRD.md` (or `scope/handoff-digest.md` if `handoff.digest` enabled) | Each FR-*/work item addressed in architecture |
 | impl | `arch/architecture.md` | Each component/module implemented |
 | qa | `scope/requirements.md` or `refine/PRD.md` | Each acceptance criterion has a test |
 | refine | `scope/requirements.md` | Each FR-* has a work item |

--- a/plugin/resources/guardrails.md
+++ b/plugin/resources/guardrails.md
@@ -22,9 +22,11 @@ Before handoff, verify your output covers upstream requirements. This closes the
 
 Read the upstream artifact from `~/.claude/circle/projects/{project}/output/`. If the first path doesn't exist, try the alternative (e.g., PRD.md if requirements.md is missing).
 
+**Digest source (only if enabled)**: if `handoff.digest` is `true` in `config.yaml` AND the upstream role wrote a `handoff-digest.md`, take your checklist from that digest's `## Verifiable items` section instead of re-reading the full upstream doc. If the flag is off or no digest exists, use the full artifact as described above (default behavior). For PR-A this applies to the `arch` role reading `scope/handoff-digest.md`; other roles keep reading the full artifact.
+
 ### Protocol
 
-1. Extract the list of checkable items from the upstream artifact (FR-*, work items, components, acceptance criteria — depending on your role's "Check For" column above).
+1. Extract the list of checkable items (FR-*, work items, components, acceptance criteria — per your role's "Check For" column). Source them from the upstream `handoff-digest.md` `## Verifiable items` section when the digest path above applies; otherwise from the full upstream artifact.
 2. For each item, assess coverage in your output:
    - ✅ **Covered** — explicitly addressed
    - ⚠️ **Partial** — mentioned but incomplete

--- a/plugin/resources/handoff-digest-template.md
+++ b/plugin/resources/handoff-digest-template.md
@@ -1,0 +1,28 @@
+# Handoff Digest Template
+
+Output this compact digest at handoff **only when** `handoff.digest: true` in the project `config.yaml`. Write it alongside (never instead of) the full document. Target ~300–600 tokens. Fill every section from THIS session's work; do not invent.
+
+```
+# Handoff Digest — {role} → {next role}
+**Source doc**: {relative path to the full document}   **Domain**: {software|business|personal|general}
+
+## Verifiable items
+| ID | Item | One-line essence |
+|----|------|------------------|
+| FR-1 | {short label} | {one line} |
+
+## Key decisions
+- {decision} — {one-line why}
+
+## Interface for next role
+- {what the next role needs to begin without opening the full doc}
+
+## Escalation hints
+- For detail on {topic}, see §{section} of the source doc
+```
+
+## Guidance
+- **Verifiable items**: one row per checkable item the downstream role and guardrails must trace (FR-*, NFR, work items, components, acceptance criteria — whatever your role produces). This list IS the guardrails checklist.
+- **Key decisions**: only choices that constrain the downstream role (e.g. explicit out-of-scope items, a chosen constraint). Skip narration.
+- **Interface for next role**: the minimal contract to start work.
+- **Escalation hints**: map topics to source-doc sections so escalation is cheap.

--- a/plugin/resources/templates/config-example.yaml
+++ b/plugin/resources/templates/config-example.yaml
@@ -37,6 +37,16 @@ tdd:
   enabled: true           # Enable TDD workflow (default: true)
   enforcement: hard       # hard = QA blocks on violation; soft = QA warns only
 
+# ─────────────────────────────────────────────────────────────────
+
+# Handoff digest (Phase 2 — token reduction)
+# When true, each role writes a compact handoff-digest.md at handoff and
+# downstream roles read it as their primary input (escalating to the full doc
+# on demand). guardrails builds its Traceability table from the digest too.
+# Currently wired on the scope→arch hop only.
+handoff:
+  digest: false           # Enable digest handoff (default: false)
+
 # Model & effort routing — assign Claude model and effort level per role
 # Roles with context: fork run as subagents and respect these settings.
 # Roles with context: same inherit the session model (settings are ignored).

--- a/plugin/skills/arch/SKILL.md
+++ b/plugin/skills/arch/SKILL.md
@@ -38,14 +38,14 @@ Detect the project domain by analyzing files in the current directory:
 
 Read requirements from `~/.claude/circle/projects/{project}/output/`:
 - **Digest-first (only if enabled)**: read `~/.claude/circle/projects/{project}/config.yaml`. If `handoff.digest` is `true` AND `scope/handoff-digest.md` exists, read the digest as your PRIMARY input instead of the full doc. **Escalation rule**: if a decision depends on a detail not present in the digest, open the source doc named in the digest (use its Escalation hints to jump to the right section) before proceeding — do not guess. If the flag is off or the digest is absent, fall back to the full doc below (default behavior).
-- Check for: `scope/requirements.md`
+- Check for (if the digest is not used): `scope/requirements.md`
 - Also check: `refine/PRD.md` (if Refiner has refined requirements)
 - If none found: "Requirements missing. Run `/circle:scope` first to gather requirements."
 
 Also check for project config: `~/.claude/circle/projects/{project}/config.yaml`
 - If `extra_instructions` for arch exists, incorporate them
 - If `context_files` defined, read those files for additional architectural context
-- **Upstream for self-verification**: `scope/requirements.md` or `refine/PRD.md` (loaded before handoff if guardrails enabled)
+- **Upstream for self-verification**: `scope/handoff-digest.md` when `handoff.digest` is `true` and it exists (see guardrails.md "Digest source"); otherwise `scope/requirements.md` or `refine/PRD.md` (loaded before handoff if guardrails enabled)
 
 ## Domain-Specific Behavior
 
@@ -136,7 +136,7 @@ These are suggestions, not blocks — proceed with or without them. If a suggest
 
 6. **Generate architecture document**: Write to `~/.claude/circle/projects/$PROJECT_NAME/output/arch/{filename}`
 
-7. **Self-Verification**: Read and follow the self-verification protocol in `${CLAUDE_PLUGIN_ROOT}/resources/guardrails.md`. Upstream artifact: `scope/requirements.md` or `refine/PRD.md`.
+7. **Self-Verification**: Read and follow the self-verification protocol in `${CLAUDE_PLUGIN_ROOT}/resources/guardrails.md`. Upstream artifact: `scope/handoff-digest.md` if `handoff.digest` is `true` and it exists (see guardrails.md "Digest source"); otherwise `scope/requirements.md` or `refine/PRD.md`.
 
 8. **MCP Integration** (if available):
    - **Domain-specific tools**: If domain-specific MCP tools are available (configured via deps-manifest.yaml), use them to look up framework documentation and platform best practices.

--- a/plugin/skills/arch/SKILL.md
+++ b/plugin/skills/arch/SKILL.md
@@ -37,6 +37,7 @@ Detect the project domain by analyzing files in the current directory:
 ## Input Prerequisites
 
 Read requirements from `~/.claude/circle/projects/{project}/output/`:
+- **Digest-first (only if enabled)**: read `~/.claude/circle/projects/{project}/config.yaml`. If `handoff.digest` is `true` AND `scope/handoff-digest.md` exists, read the digest as your PRIMARY input instead of the full doc. **Escalation rule**: if a decision depends on a detail not present in the digest, open the source doc named in the digest (use its Escalation hints to jump to the right section) before proceeding — do not guess. If the flag is off or the digest is absent, fall back to the full doc below (default behavior).
 - Check for: `scope/requirements.md`
 - Also check: `refine/PRD.md` (if Refiner has refined requirements)
 - If none found: "Requirements missing. Run `/circle:scope` first to gather requirements."

--- a/plugin/skills/scope/SKILL.md
+++ b/plugin/skills/scope/SKILL.md
@@ -109,13 +109,20 @@ Detect the project domain by analyzing files in the current directory:
 
 5. **Save output** to: `~/.claude/circle/projects/$PROJECT_NAME/output/scope/{filename}`
 
-6. **MCP Integration** (if available):
+6. **Write handoff digest** (only if enabled): Read `~/.claude/circle/projects/$PROJECT_NAME/config.yaml`. If `handoff.digest` is not `true`, skip this step entirely (default). Otherwise, read `${CLAUDE_PLUGIN_ROOT}/resources/handoff-digest-template.md` and write a filled digest to `~/.claude/circle/projects/$PROJECT_NAME/output/scope/handoff-digest.md`:
+   - **Verifiable items**: one row per FR-* and NFR in the requirements doc, each with a one-line essence.
+   - **Key decisions**: scope choices that constrain downstream (e.g. explicit Out-of-Scope items).
+   - **Interface for next role**: what the Architecture Owner needs to begin.
+   - **Escalation hints**: map topics to sections of the source doc (`{filename}`).
+   Keep it ~300–600 tokens. The full document from step 5 is always still written — the digest is additive.
+
+7. **MCP Integration** (if available):
    - **Linear**: Create or link requirements to Linear issues for traceability
    - **claude-mem**: Search for relevant past requirements work.
 
-7. **Work Summary**: Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
+8. **Work Summary**: Before the handoff message, read `${CLAUDE_PLUGIN_ROOT}/resources/work-summary-template.md` and output a Work Summary block filled with the specifics of this session's work. This block is captured by claude-mem for assessment tracking. If the template file is not found, skip this step silently.
 
-8. **Handoff**:
+9. **Handoff**:
    > **Scope Clarifier — Complete.**
    > Output saved to: `~/.claude/circle/projects/{project}/output/scope/{filename}`
    > Next suggested role: `/circle:refine` for product prioritization, or `/circle:arch` for architecture design.


### PR DESCRIPTION
## What

Phase 2 PR-A of the token-reduction work: a compact **handoff digest** mechanism between roles, wired on the **scope→arch hop only**, entirely behind config flag `handoff.digest` (**default OFF**). Includes the approved design spec and implementation plan.

## Why

Profiling showed each fork-context role costs 100K–460K *fresh* tokens/invocation, dominated by **full upstream-doc reloads** plus a **second full read inside `guardrails.md`** self-verification. This introduces a small structured artifact so the downstream role and guardrails read a digest instead of the whole document. (Phase 1, boilerplate compression v2.4.1, shipped in #46.)

## How it works (spec: `docs/superpowers/specs/2026-07-08-circle-digest-handoff-design.md`)

- **Producer**: `scope` writes `scope/handoff-digest.md` at handoff — additive; the full `requirements.md` is always still written.
- **Consumer**: `arch` reads the digest **first**, escalating to the full doc **on demand** (explicit rule: "if a decision needs a detail not in the digest, open the source doc — do not guess").
- **Unification**: `guardrails` builds its Traceability checklist from the digest's *Verifiable items* — removing the second full-doc read.
- **Flag**: `handoff.digest` (default `false`). OFF = identical to today. ON-but-missing-digest = graceful fallback to the full doc.

## Commits

- `75cf417` template · `ef0024c` scope producer · `101c636` arch digest-first · `6385f91` guardrails-from-digest · `7ce4d38` config docs · `11c9e6c` fix (route arch self-verification through the digest)

## Reviewer notes

- **No behavior change when the flag is off** — every new block is gated on `handoff.digest: true` (consumers also require the digest file to exist).
- **No version bump** in this PR (that's PR-B, which flips the default ON after one-hop token measurement — see spec §5).
- Built via subagent-driven execution; per-task reviews + a final whole-branch review (one Important finding on arch self-verification, fixed in `11c9e6c`).
- **Not yet done** (post-merge or pre-merge, your call): the OFF-vs-ON token measurement on scope→arch that gates PR-B.

## Files
`handoff-digest-template.md` (new), `scope/SKILL.md`, `arch/SKILL.md`, `guardrails.md`, `CUSTOMIZATION.md`, `config-example.yaml` + spec & plan docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)